### PR TITLE
esp8266: serial swap & softserial + debug on separate tcp server while printing

### DIFF
--- a/esp3d/bridge.cpp
+++ b/esp3d/bridge.cpp
@@ -68,7 +68,13 @@ void BRIDGE::print (const char * data, tpipe output)
             buffer_web="";
         }
         break;
-    default:
+#ifdef SERIAL_SWAP
+    case SWSERIAL_PIPE:
+        ESP_SWSERIAL_OUT.print(data);
+        break;
+#endif
+    case NO_PIPE:
+    case SERIAL1_PIPE:
         break;
     }
 }

--- a/esp3d/bridge.h
+++ b/esp3d/bridge.h
@@ -24,6 +24,9 @@
 #include "config.h"
 #ifdef TCP_IP_DATA_FEATURE
 extern WiFiServer * data_server;
+#if defined(DEBUG_ESP3D) && defined(DEBUG_OUTPUT_TCP)
+extern WiFiServer * debug_server;
+#endif
 #endif
 
 class BRIDGE
@@ -41,9 +44,9 @@ public:
     static void flush (tpipe output);
 #ifdef TCP_IP_DATA_FEATURE
     static void processFromTCP2Serial();
-    static void send2TCP(const __FlashStringHelper *data);
-    static void send2TCP(String data);
-    static void send2TCP(const char * data);
+    static void send2TCP(const __FlashStringHelper *data, bool debug = false);
+    static void send2TCP(String data, bool debug = false);
+    static void send2TCP(const char * data, bool debug = false);
 #endif
 };
 #endif

--- a/esp3d/command.cpp
+++ b/esp3d/command.cpp
@@ -1250,7 +1250,7 @@ bool COMMAND::execute_command(int cmd,String cmd_params, tpipe output, level_aut
                             String cmd_part1=currentline.substring(ESPpos+4,ESPpos2);
                             String cmd_part2="";
                             //is there space for parameters?
-                            if (ESPpos2<currentline.length()) {
+                            if (ESPpos2<(int)currentline.length()) {
                                 cmd_part2=currentline.substring(ESPpos2+1);
                             }
                             //if command is a valid number then execute command
@@ -1409,6 +1409,7 @@ bool COMMAND::execute_command(int cmd,String cmd_params, tpipe output, level_aut
 
 bool COMMAND::check_command(String buffer, tpipe output, bool handlelockserial)
 {
+    (void)handlelockserial;
     String buffer2;
     LOG("Check Command:")
     LOG(buffer)
@@ -1475,7 +1476,7 @@ if (CONFIG::GetFirmwareTarget()  == SMOOTHIEWARE) {
                 String cmd_part1=buffer.substring(ESPpos+4,ESPpos2);
                 String cmd_part2="";
                 //is there space for parameters?
-                if (ESPpos2<buffer.length()) {
+                if (ESPpos2<(int)buffer.length()) {
                     cmd_part2=buffer.substring(ESPpos2+1);
                 }
                 //if command is a valid number then execute command
@@ -1523,7 +1524,7 @@ if (CONFIG::GetFirmwareTarget()  == SMOOTHIEWARE) {
 //read a buffer in an array
 void COMMAND::read_buffer_serial(uint8_t *b, size_t len)
 {
-    for (long i = 0; i< len; i++) {
+    for (size_t i = 0; i< len; i++) {
         read_buffer_serial(b[i]);
        //*b++;
     }

--- a/esp3d/command.cpp
+++ b/esp3d/command.cpp
@@ -1123,9 +1123,9 @@ bool COMMAND::execute_command(int cmd,String cmd_params, tpipe output, level_aut
     //output is JSON or plain text according parameter
     //[ESP410]<plain>
     case 410: {
-		parameter = get_param(cmd_params,"", true);
-		int n = WiFi.scanNetworks();
-		bool plain = parameter == "plain";
+        parameter = get_param(cmd_params,"", true);
+        int n = WiFi.scanNetworks();
+        bool plain = parameter == "plain";
         if (!plain)BRIDGE::print(F("{\"AP_LIST\":["), output);
         for (int i = 0; i < n; ++i) {
                 if (i>0) {
@@ -1151,15 +1151,15 @@ bool COMMAND::execute_command(int cmd,String cmd_params, tpipe output, level_aut
         if (!plain)BRIDGE::print(F("]}"), output);
         else BRIDGE::print(F("\n"), output);
         WiFi.scanDelete();
-	}
-	break;
-	//Get ESP current status in plain or JSON
+    }
+    break;
+    //Get ESP current status in plain or JSON
     //[ESP420]<plain>
     case 420: {
-		parameter = get_param(cmd_params,"", true);
+        parameter = get_param(cmd_params,"", true);
         CONFIG::print_config(output, (parameter == "plain"));
-	}
-	break;
+    }
+    break;
     //Set ESP mode
     //cmd is RESET, SAFEMODE, RESTART
     //[ESP444]<cmd>pwd=<admin password>
@@ -1281,43 +1281,43 @@ bool COMMAND::execute_command(int cmd,String cmd_params, tpipe output, level_aut
     //Format SPIFFS
     //[ESP710]FORMAT pwd=<admin password>
     case 710: 
-		parameter = get_param(cmd_params,"", true);
+        parameter = get_param(cmd_params,"", true);
 #ifdef AUTHENTICATION_FEATURE
         if (auth_type != LEVEL_ADMIN) {
             BRIDGE::println(INCORRECT_CMD_MSG, output);
             response = false;
         } else
 #endif 
-		{
-		if (parameter=="FORMAT") {
-			 BRIDGE::print(F("Formating"), output);
-			 //SPIFFS.end();
-			 delay(0);
-			 SPIFFS.format();
-			 //SPIFFS.begin();
-			 BRIDGE::println(F("...Done"), output);
+        {
+            if (parameter=="FORMAT") {
+                BRIDGE::print(F("Formating"), output);
+                //SPIFFS.end();
+                delay(0);
+                SPIFFS.format();
+                //SPIFFS.begin();
+                BRIDGE::println(F("...Done"), output);
             } else {
-			BRIDGE::println(INCORRECT_CMD_MSG, output);
-			response = false;
+                BRIDGE::println(INCORRECT_CMD_MSG, output);
+                response = false;
             }
         }
         break;
      //SPIFFS total size and used size
     //[ESP720]<header answer>
     case 720: 
-		BRIDGE::print(cmd_params, output);
+        BRIDGE::print(cmd_params, output);
 #ifdef ARDUINO_ARCH_ESP8266   
-		fs::FSInfo info;
-		SPIFFS.info(info);
-		BRIDGE::print("SPIFFS Total:", output);
-		BRIDGE::print(CONFIG::formatBytes(info.totalBytes).c_str(), output);
-		BRIDGE::print(" Used:", output);
-		BRIDGE::println(CONFIG::formatBytes(info.usedBytes).c_str(), output);
+        fs::FSInfo info;
+        SPIFFS.info(info);
+        BRIDGE::print("SPIFFS Total:", output);
+        BRIDGE::print(CONFIG::formatBytes(info.totalBytes).c_str(), output);
+        BRIDGE::print(" Used:", output);
+        BRIDGE::println(CONFIG::formatBytes(info.usedBytes).c_str(), output);
 #else
-		BRIDGE::print("SPIFFS  Total:", output);
-		BRIDGE::print(CONFIG::formatBytes(SPIFFS.totalBytes()).c_str(), output);
-		BRIDGE::print(" Used:", output);
-		BRIDGE::println(CONFIG::formatBytes(SPIFFS.usedBytes()).c_str(), output);
+        BRIDGE::print("SPIFFS  Total:", output);
+        BRIDGE::print(CONFIG::formatBytes(SPIFFS.totalBytes()).c_str(), output);
+        BRIDGE::print(" Used:", output);
+        BRIDGE::println(CONFIG::formatBytes(SPIFFS.usedBytes()).c_str(), output);
 #endif
         break;
     //get fw version firmare target and fw version

--- a/esp3d/command.cpp
+++ b/esp3d/command.cpp
@@ -129,16 +129,16 @@ bool COMMAND::execute_command(int cmd,String cmd_params, tpipe output, level_aut
           LOG("user identified\r\n");
     }
 #ifdef DEBUG_ESP3D
-    if ( auth_type == LEVEL_ADMIN)  
+    if ( auth_type == LEVEL_ADMIN)
         {
             LOG("admin identified\r\n");
         }
     else  {
-        if( auth_type == LEVEL_USER)  
+        if( auth_type == LEVEL_USER)
             {
                 LOG("user identified\r\n");
             }
-        else  
+        else
             {
                 LOG("guest identified\r\n");
             }
@@ -442,7 +442,7 @@ bool COMMAND::execute_command(int cmd,String cmd_params, tpipe output, level_aut
                                 if (pin < MAX_GPIO) {
                                     LOG("Set as input pull up\r\n")
                                     pinMode(pin, INPUT_PULLUP);
-                                } 
+                                }
 #ifdef ARDUINO_ARCH_ESP8266
                                 else {
                                     LOG("Set as input pull down 16\r\n")
@@ -536,7 +536,7 @@ bool COMMAND::execute_command(int cmd,String cmd_params, tpipe output, level_aut
         //Start JSON
         BRIDGE::println(F("{\"EEPROM\":["), output);
         if (cmd_params == "network" || cmd_params == "") {
-            
+
             //1- Baud Rate
             BRIDGE::print(F("{\"F\":\"network\",\"P\":\""), output);
             BRIDGE::print((const char *)CONFIG::intTostr(EP_BAUD_RATE), output);
@@ -548,7 +548,7 @@ bool COMMAND::execute_command(int cmd,String cmd_params, tpipe output, level_aut
             }
             BRIDGE::print(F("\",\"H\":\"Baud Rate\",\"O\":[{\"9600\":\"9600\"},{\"19200\":\"19200\"},{\"38400\":\"38400\"},{\"57600\":\"57600\"},{\"115200\":\"115200\"},{\"230400\":\"230400\"},{\"250000\":\"250000\"}]}"), output);
             BRIDGE::println(F(","), output);
-            
+
             //2-Sleep Mode
             BRIDGE::print(F("{\"F\":\"network\",\"P\":\""), output);
             BRIDGE::print((const char *)CONFIG::intTostr(EP_SLEEP_MODE), output);
@@ -568,7 +568,7 @@ bool COMMAND::execute_command(int cmd,String cmd_params, tpipe output, level_aut
             BRIDGE::print((const char *)CONFIG::intTostr(WIFI_MODEM_SLEEP), output);
             BRIDGE::print(F("\"}]}"), output);
             BRIDGE::println(F(","), output);
-            
+
             //3-Web Port
             BRIDGE::print(F("{\"F\":\"network\",\"P\":\""), output);
             BRIDGE::print((const char *)CONFIG::intTostr(EP_WEB_PORT), output);
@@ -648,7 +648,7 @@ bool COMMAND::execute_command(int cmd,String cmd_params, tpipe output, level_aut
             BRIDGE::print((const char *)CONFIG::intTostr(MIN_HOSTNAME_LENGTH), output);
             BRIDGE::print(F("\"}"), output);
             BRIDGE::println(F(","), output);
-            
+
             //8-wifi mode
             BRIDGE::print(F("{\"F\":\"network\",\"P\":\""), output);
             BRIDGE::print((const char *)CONFIG::intTostr(EP_WIFI_MODE), output);
@@ -692,7 +692,7 @@ bool COMMAND::execute_command(int cmd,String cmd_params, tpipe output, level_aut
             BRIDGE::print((const char *)CONFIG::intTostr(MIN_PASSWORD_LENGTH), output);
             BRIDGE::print(F("\"}"), output);
             BRIDGE::println(F(","), output);
-            
+
             //11-Station Network Mode
             BRIDGE::print(F("{\"F\":\"network\",\"P\":\""), output);
             BRIDGE::print((const char *)CONFIG::intTostr(EP_STA_PHY_MODE), output);
@@ -818,7 +818,7 @@ bool COMMAND::execute_command(int cmd,String cmd_params, tpipe output, level_aut
             }
             BRIDGE::print(F("\",\"H\":\"SSID Visible\",\"O\":[{\"No\":\"0\"},{\"Yes\":\"1\"}]}"), output);
             BRIDGE::println(F(","), output);
-            
+
             //20-AP Channel
             BRIDGE::print(F("{\"F\":\"network\",\"P\":\""), output);
             BRIDGE::print((const char *)CONFIG::intTostr(EP_CHANNEL), output);
@@ -910,7 +910,7 @@ bool COMMAND::execute_command(int cmd,String cmd_params, tpipe output, level_aut
             BRIDGE::print(F("\",\"H\":\"AP Static Gateway\"}"), output);
             delay(0);
         }
-        
+
         if (cmd_params == "printer" || cmd_params == "") {
             if (cmd_params == "") {
                 BRIDGE::println(F(","), output);
@@ -938,7 +938,7 @@ bool COMMAND::execute_command(int cmd,String cmd_params, tpipe output, level_aut
             BRIDGE::print((const char *)CONFIG::intTostr(UNKNOWN_FW), output);
             BRIDGE::print(F("\"}]}"), output);
             BRIDGE::println(F(","), output);
-            
+
             //Refresh time 1
             BRIDGE::print(F("{\"F\":\"printer\",\"P\":\""), output);
             BRIDGE::print((const char *)CONFIG::intTostr(EP_REFRESH_PAGE_TIME), output);
@@ -954,7 +954,7 @@ bool COMMAND::execute_command(int cmd,String cmd_params, tpipe output, level_aut
             BRIDGE::print((const char *)CONFIG::intTostr(DEFAULT_MIN_REFRESH), output);
             BRIDGE::print(F("\"}"), output);
             BRIDGE::println(F(","), output);
-            
+
             //Refresh time 2
             BRIDGE::print(F("{\"F\":\"printer\",\"P\":\""), output);
             BRIDGE::print((const char *)CONFIG::intTostr(EP_REFRESH_PAGE_TIME2), output);
@@ -1118,7 +1118,7 @@ bool COMMAND::execute_command(int cmd,String cmd_params, tpipe output, level_aut
 
     }
     break;
-    
+
     //Get available AP list (limited to 30)
     //output is JSON or plain text according parameter
     //[ESP410]<plain>
@@ -1266,7 +1266,7 @@ bool COMMAND::execute_command(int cmd,String cmd_params, tpipe output, level_aut
                         delay(0);
                         ESP_SERIAL_OUT.flush();
                     }
-                 delay(0);   
+                 delay(0);
                 }
             }
             currentfile.close();
@@ -1280,14 +1280,14 @@ bool COMMAND::execute_command(int cmd,String cmd_params, tpipe output, level_aut
     }
     //Format SPIFFS
     //[ESP710]FORMAT pwd=<admin password>
-    case 710: 
+    case 710:
         parameter = get_param(cmd_params,"", true);
 #ifdef AUTHENTICATION_FEATURE
         if (auth_type != LEVEL_ADMIN) {
             BRIDGE::println(INCORRECT_CMD_MSG, output);
             response = false;
         } else
-#endif 
+#endif
         {
             if (parameter=="FORMAT") {
                 BRIDGE::print(F("Formating"), output);
@@ -1304,9 +1304,9 @@ bool COMMAND::execute_command(int cmd,String cmd_params, tpipe output, level_aut
         break;
      //SPIFFS total size and used size
     //[ESP720]<header answer>
-    case 720: 
+    case 720:
         BRIDGE::print(cmd_params, output);
-#ifdef ARDUINO_ARCH_ESP8266   
+#ifdef ARDUINO_ARCH_ESP8266
         fs::FSInfo info;
         SPIFFS.info(info);
         BRIDGE::print("SPIFFS Total:", output);
@@ -1329,7 +1329,7 @@ bool COMMAND::execute_command(int cmd,String cmd_params, tpipe output, level_aut
         BRIDGE::print(F("FW version:"), output);
         BRIDGE::print(FW_VERSION, output);
         BRIDGE::print(F(" # FW target:"), output);
-        BRIDGE::print(CONFIG::GetFirmwareTargetShortName(), output);      
+        BRIDGE::print(CONFIG::GetFirmwareTargetShortName(), output);
         BRIDGE::print(F(" # FW HW:"), output);
         if (CONFIG::is_direct_sd) BRIDGE::print(F("Direct SD"), output);
         else  BRIDGE::print(F("Serial SD"), output);
@@ -1426,7 +1426,7 @@ bool COMMAND::check_command(String buffer, tpipe output, bool handlelockserial)
         if (buffer.startsWith("ok")) {
             return false;
         }
-    }   
+    }
 #ifdef ERROR_MSG_FEATURE
         int Errorpos = -1;
 #endif
@@ -1517,7 +1517,7 @@ if (CONFIG::GetFirmwareTarget()  == SMOOTHIEWARE) {
             (web_interface->info_msg).add(ss.c_str());
         }
 #endif
-    
+
     return is_temp;
 }
 

--- a/esp3d/config.cpp
+++ b/esp3d/config.cpp
@@ -729,7 +729,7 @@ bool CONFIG::isHostnameValid(const char * hostname)
         return false;
     }
     //only letter and digit
-    for (int i=0; i < strlen(hostname); i++) {
+    for (size_t i=0; i < strlen(hostname); i++) {
         c = hostname[i];
         if (!(isdigit(c) || isalpha(c) || c=='_')) {
             return false;
@@ -749,7 +749,7 @@ bool CONFIG::isSSIDValid(const char * ssid)
         return false;
     }
     //only letter and digit
-    for (int i=0; i < strlen(ssid); i++) {
+    for (size_t i=0; i < strlen(ssid); i++) {
         if (!isPrintable(ssid[i]))return false;
         //if (!(isdigit(c) || isalpha(c))) return false;
         //if (c==' ') {
@@ -769,7 +769,7 @@ bool CONFIG::isPasswordValid(const char * password)
     if (strlen(password)<MIN_PASSWORD_LENGTH)) return false;
     #endif 
     //no space allowed
-    for (int i=0; i < strlen(password); i++)
+    for (size_t i=0; i < strlen(password); i++)
         if (password[i] == ' ') {
             return false;
         }
@@ -784,7 +784,7 @@ bool CONFIG::isLocalPasswordValid(const char * password)
         return false;
     }
     //no space allowed
-    for (int i=0; i < strlen(password); i++) {
+    for (size_t i=0; i < strlen(password); i++) {
         c= password[i];
         if (c==' ') {
             return false;
@@ -809,7 +809,7 @@ bool CONFIG::isIPValid(const char * IP)
         return false;
     }
     //only letter and digit
-    for (int i=0; i < strlen(IP); i++) {
+    for (size_t i=0; i < strlen(IP); i++) {
         c = IP[i];
         if (isdigit(c)) {
             //only 3 digit at once
@@ -1689,7 +1689,7 @@ void CONFIG::print_config(tpipe output, bool plaintext)
 #endif
         String stmp ="";
 #ifdef ARDUINO_ARCH_ESP32
-		for (int i=0; i < station.num; i++){
+        for (int i=0; i < station.num; i++){
 #else
         while(station) {
 #endif

--- a/esp3d/config.cpp
+++ b/esp3d/config.cpp
@@ -449,7 +449,7 @@ bool CONFIG::update_settings(){
                         }
                     }
                 }
-                
+
                 //Timezone
                 if (espconfig.getValue("network", "time_zone", buffer, bufferLen, itmp)) {
                     bflag = itmp;
@@ -457,7 +457,7 @@ bool CONFIG::update_settings(){
                         success = false;
                     }
                 }
-                
+
                 //day saving time
                 if (espconfig.getValue("network", "day_st", buffer, bufferLen)) {
                     stmp = buffer;
@@ -486,7 +486,7 @@ bool CONFIG::update_settings(){
                         success = false;
                     }
                 }
-                
+
                 //time server 2
                 if (espconfig.getValue("network", "time_server_2", buffer, bufferLen)) {
                     if (strlen(buffer) > 128) {
@@ -495,7 +495,7 @@ bool CONFIG::update_settings(){
                         success = false;
                     }
                 }
-                
+
                 //time server 3
                 if (espconfig.getValue("network", "time_server_3", buffer, bufferLen)) {
                     if (strlen(buffer) > 128) {
@@ -504,7 +504,7 @@ bool CONFIG::update_settings(){
                         success = false;
                     }
                 }
-                
+
                 //Section [printer]
                 //data = 192.168.1.1/video.cgi?user=luc&pwd=mypassword
                 if (espconfig.getValue("printer", "data", buffer, bufferLen)) {
@@ -546,7 +546,7 @@ bool CONFIG::update_settings(){
                         success = false;
                     }
                 }
-                
+
                  //target_printer= smoothieware
                 if (espconfig.getValue("printer", "target_printer", buffer, bufferLen)) {
                     stmp = buffer;
@@ -561,7 +561,7 @@ bool CONFIG::update_settings(){
                         success = false;
                     }
                 }
-                
+
                 //direct sd connection
                 if (espconfig.getValue("printer", "direct_sd", buffer, bufferLen)) {
                     stmp = buffer;
@@ -622,7 +622,7 @@ bool CONFIG::update_settings(){
                         }
                     }
                 }
-                
+
                 //primary sd directory
                 if (espconfig.getValue("printer", "primary_sd ", buffer, bufferLen)) {
                     stmp = buffer;
@@ -634,7 +634,7 @@ bool CONFIG::update_settings(){
                     } else  if (stmp =="sd") {
                         bflag = 1;
                     } else  if (stmp =="ext") {
-                        bflag = 2;                        
+                        bflag = 2;
                     } else {
                         localerror = true;
                         success = false;
@@ -645,7 +645,7 @@ bool CONFIG::update_settings(){
                         }
                     }
                 }
-            
+
                  //secondary sd directory
                 if (espconfig.getValue("printer", "secondary_sd  ", buffer, bufferLen)) {
                     stmp = buffer;
@@ -657,7 +657,7 @@ bool CONFIG::update_settings(){
                     } else  if (stmp =="sd") {
                         bflag = 1;
                     } else  if (stmp =="ext") {
-                        bflag = 2;                      
+                        bflag = 2;
                     } else {
                         localerror = true;
                         success = false;
@@ -668,7 +668,7 @@ bool CONFIG::update_settings(){
                         }
                     }
                 }
-            
+
             }
             espconfig.close();
             if(success) {
@@ -1039,7 +1039,7 @@ bool CONFIG::check_update_presence( ){
         String current_line;
         //int pos;
         int temp_counter = 0;
-       
+
         //pickup the list
         while (count < MAX_TRY) {
             //give some time between each buffer
@@ -1275,35 +1275,35 @@ bool CONFIG::reset_config()
     if(!CONFIG::write_string(EP_USER_PWD,FPSTR(DEFAULT_USER_PWD))) {
         return false;
     }
-    
+
     if(!CONFIG::write_byte(EP_TARGET_FW, UNKNOWN_FW)) {
         return false;
     }
-    
+
     if(!CONFIG::write_byte(EP_TIMEZONE, DEFAULT_TIME_ZONE)) {
         return false;
     }
-    
+
     if(!CONFIG::write_byte(EP_TIME_ISDST, DEFAULT_TIME_DST)) {
         return false;
     }
-    
+
      if(!CONFIG::write_byte(EP_PRIMARY_SD, DEFAULT_PRIMARY_SD)) {
         return false;
     }
-    
+
      if(!CONFIG::write_byte(EP_SECONDARY_SD, DEFAULT_SECONDARY_SD)) {
         return false;
     }
-    
+
     if(!CONFIG::write_byte(EP_IS_DIRECT_SD, DEFAULT_IS_DIRECT_SD)) {
         return false;
     }
-    
+
      if(!CONFIG::write_byte(EP_DIRECT_SD_CHECK, DEFAULT_DIRECT_SD_CHECK)) {
         return false;
     }
-    
+
     if(!CONFIG::write_byte(EP_SD_CHECK_UPDATE_AT_BOOT, DEFAULT_SD_CHECK_UPDATE_AT_BOOT)) {
         return false;
     }
@@ -1311,11 +1311,11 @@ bool CONFIG::reset_config()
     if(!CONFIG::write_string(EP_TIME_SERVER1,FPSTR(DEFAULT_TIME_SERVER1))) {
         return false;
     }
-    
+
     if(!CONFIG::write_string(EP_TIME_SERVER2,FPSTR(DEFAULT_TIME_SERVER2))) {
         return false;
     }
-    
+
     if(!CONFIG::write_string(EP_TIME_SERVER3,FPSTR(DEFAULT_TIME_SERVER3))) {
         return false;
     }
@@ -1323,7 +1323,7 @@ bool CONFIG::reset_config()
 }
 
 void CONFIG::print_config(tpipe output, bool plaintext)
-{    
+{
     if (!plaintext)BRIDGE::print(F("{\"chip_id\":\""), output);
     else BRIDGE::print(F("Chip ID: "), output);
 #ifdef ARDUINO_ARCH_ESP8266
@@ -1333,27 +1333,27 @@ void CONFIG::print_config(tpipe output, bool plaintext)
 #endif
     if (!plaintext)BRIDGE::print(F("\","), output);
     else BRIDGE::print(F("\n"), output);
-    
+
     if (!plaintext)BRIDGE::print(F("\"cpu\":\""), output);
     else BRIDGE::print(F("CPU Frequency: "), output);
     BRIDGE::print(String(ESP.getCpuFreqMHz()).c_str(), output);
     if (plaintext)BRIDGE::print(F("Mhz"), output);
     if (!plaintext)BRIDGE::print(F("\","), output);
     else BRIDGE::print(F("\n"), output);
-#ifdef ARDUINO_ARCH_ESP32 
+#ifdef ARDUINO_ARCH_ESP32
     if (!plaintext)BRIDGE::print(F("\"cpu_temp\":\""), output);
     else BRIDGE::print(F("CPU Temperature: "), output);
     BRIDGE::print(String(temperatureRead(),1).c_str(), output);
     if (plaintext)BRIDGE::print(F("C"), output);
     if (!plaintext)BRIDGE::print(F("\","), output);
     else BRIDGE::print(F("\n"), output);
-#endif  
+#endif
     if (!plaintext)BRIDGE::print(F("\"freemem\":\""), output);
     else BRIDGE::print(F("Free memory: "), output);
     BRIDGE::print(formatBytes(ESP.getFreeHeap()).c_str(), output);
     if (!plaintext)BRIDGE::print(F("\","), output);
     else BRIDGE::print(F("\n"), output);
-    
+
     if (!plaintext)BRIDGE::print(F("\""), output);
     BRIDGE::print(F("SDK"), output);
     if (!plaintext)BRIDGE::print(F("\":\""), output);
@@ -1361,13 +1361,13 @@ void CONFIG::print_config(tpipe output, bool plaintext)
     BRIDGE::print(ESP.getSdkVersion(), output);
     if (!plaintext)BRIDGE::print(F("\","), output);
     else BRIDGE::print(F("\n"), output);
-      
+
     if (!plaintext)BRIDGE::print(F("\"flash_size\":\""), output);
     else BRIDGE::print(F("Flash Size: "), output);
     BRIDGE::print(formatBytes(ESP.getFlashChipSize()).c_str(), output);
     if (!plaintext)BRIDGE::print(F("\","), output);
     else BRIDGE::print(F("\n"), output);
-#ifdef ARDUINO_ARCH_ESP8266 
+#ifdef ARDUINO_ARCH_ESP8266
     fs::FSInfo info;
     SPIFFS.info(info);
     if (!plaintext)BRIDGE::print(F("\"update_size\":\""), output);
@@ -1383,11 +1383,11 @@ void CONFIG::print_config(tpipe output, bool plaintext)
 
     if (!plaintext)BRIDGE::print(F("\"spiffs_size\":\""), output);
     else BRIDGE::print(F("Available Size for SPIFFS: "), output);
-   
+
     BRIDGE::print(formatBytes(info.totalBytes).c_str(), output);
     if (!plaintext)BRIDGE::print(F("\","), output);
     else BRIDGE::print(F("\n"), output);
-#else 
+#else
     if (!plaintext)BRIDGE::print(F("\"update_size\":\""), output);
     else BRIDGE::print(F("Available Size for update: "), output);
     uint32_t  flashsize = ESP.getFlashChipSize();
@@ -1440,7 +1440,7 @@ void CONFIG::print_config(tpipe output, bool plaintext)
     }
     if (!plaintext)BRIDGE::print(F("\","), output);
     else BRIDGE::print(F("\n"), output);
-    
+
     if (!plaintext)BRIDGE::print(F("\"channel\":\""), output);
     else BRIDGE::print(F("Channel: "), output);
     BRIDGE::print(String(WiFi.channel()).c_str(), output);
@@ -1450,7 +1450,7 @@ void CONFIG::print_config(tpipe output, bool plaintext)
     uint8_t PhyMode;
     if (WiFi.getMode() == WIFI_STA)esp_wifi_get_protocol(ESP_IF_WIFI_STA, &PhyMode);
     else esp_wifi_get_protocol(ESP_IF_WIFI_AP, &PhyMode);
-#else   
+#else
     WiFiPhyMode_t PhyMode = WiFi.getPhyMode();
 #endif
     if (!plaintext)BRIDGE::print(F("\"phy_mode\":\""), output);
@@ -1461,13 +1461,13 @@ void CONFIG::print_config(tpipe output, bool plaintext)
     else BRIDGE::print(F("???"), output);
     if (!plaintext)BRIDGE::print(F("\","), output);
     else BRIDGE::print(F("\n"), output);
-    
+
     if (!plaintext)BRIDGE::print(F("\"web_port\":\""), output);
     else BRIDGE::print(F("Web port: "), output);
     BRIDGE::print(String(wifi_config.iweb_port).c_str(), output);
     if (!plaintext)BRIDGE::print(F("\","), output);
     else BRIDGE::print(F("\n"), output);
-    
+
     if (!plaintext)BRIDGE::print(F("\"data_port\":\""), output);
     else BRIDGE::print(F("Data port: "), output);
 #ifdef TCP_IP_DATA_FEATURE
@@ -1477,7 +1477,7 @@ void CONFIG::print_config(tpipe output, bool plaintext)
 #endif
     if (!plaintext)BRIDGE::print(F("\","), output);
     else BRIDGE::print(F("\n"), output);
-    
+
     if (WiFi.getMode() == WIFI_STA || WiFi.getMode() == WIFI_AP_STA) {
         if (!plaintext)BRIDGE::print(F("\"hostname\":\""), output);
         else BRIDGE::print(F("Hostname: "), output);
@@ -1536,7 +1536,7 @@ void CONFIG::print_config(tpipe output, bool plaintext)
         tcpip_adapter_dhcpc_get_status(TCPIP_ADAPTER_IF_STA, &dhcp_status);
         if (dhcp_status == TCPIP_ADAPTER_DHCP_STARTED)
 #else
-        if (wifi_station_dhcpc_status()==DHCP_STARTED) 
+        if (wifi_station_dhcpc_status()==DHCP_STARTED)
 #endif
         {
             BRIDGE::print(F("DHCP"), output);
@@ -1544,31 +1544,31 @@ void CONFIG::print_config(tpipe output, bool plaintext)
         else BRIDGE::print(F("Static"), output);
          if (!plaintext)BRIDGE::print(F("\","), output);
         else BRIDGE::print(F("\n"), output);
-        
+
         if (!plaintext)BRIDGE::print(F("\"ip\":\""), output);
         else BRIDGE::print(F("IP: "), output);
         BRIDGE::print(WiFi.localIP().toString().c_str(), output);
         if (!plaintext)BRIDGE::print(F("\","), output);
         else BRIDGE::print(F("\n"), output);
-        
+
         if (!plaintext)BRIDGE::print(F("\"gw\":\""), output);
         else BRIDGE::print(F("Gateway: "), output);
         BRIDGE::print(WiFi.gatewayIP().toString().c_str(), output);
         if (!plaintext)BRIDGE::print(F("\","), output);
         else BRIDGE::print(F("\n"), output);
-        
+
         if (!plaintext)BRIDGE::print(F("\"msk\":\""), output);
         else BRIDGE::print(F("Mask: "), output);
         BRIDGE::print(WiFi.subnetMask().toString().c_str(), output);
         if (!plaintext)BRIDGE::print(F("\","), output);
         else BRIDGE::print(F("\n"), output);
-        
+
         if (!plaintext)BRIDGE::print(F("\"dns\":\""), output);
         else BRIDGE::print(F("DNS: "), output);
         BRIDGE::print(WiFi.dnsIP().toString().c_str(), output);
         if (!plaintext)BRIDGE::print(F("\","), output);
         else BRIDGE::print(F("\n"), output);
-        
+
         if (!plaintext)BRIDGE::print(F("\"disabled_mode\":\""), output);
         else BRIDGE::print(F("Disabled Mode: "), output);
         BRIDGE::print(F("Access Point ("), output);
@@ -1576,14 +1576,14 @@ void CONFIG::print_config(tpipe output, bool plaintext)
         BRIDGE::print(F(")"), output);
         if (!plaintext)BRIDGE::print(F("\","), output);
         else BRIDGE::print(F("\n"), output);
-        
+
     } else if (WiFi.getMode() == WIFI_AP) {
         BRIDGE::print(F("Access Point ("), output);
         BRIDGE::print(WiFi.softAPmacAddress().c_str(), output);
         BRIDGE::print(F(")"), output);
         if (!plaintext)BRIDGE::print(F("\","), output);
         else BRIDGE::print(F("\n"), output);
-        
+
         //get current config
 #ifdef ARDUINO_ARCH_ESP32
         wifi_ap_config_t apconfig;
@@ -1605,13 +1605,13 @@ void CONFIG::print_config(tpipe output, bool plaintext)
 #endif
         if (!plaintext)BRIDGE::print(F("\","), output);
         else BRIDGE::print(F("\n"), output);
-        
+
         if (!plaintext)BRIDGE::print(F("\"ssid_visible\":\""), output);
         else BRIDGE::print(F("Visible: "), output);
         BRIDGE::print((apconfig.ssid_hidden == 0)?F("Yes"):F("No"), output);
         if (!plaintext)BRIDGE::print(F("\","), output);
         else BRIDGE::print(F("\n"), output);
-        
+
         if (!plaintext)BRIDGE::print(F("\"ssid_authentication\":\""), output);
         else BRIDGE::print(F("Authentication: "), output);
         if (apconfig.authmode==AUTH_OPEN) {
@@ -1627,13 +1627,13 @@ void CONFIG::print_config(tpipe output, bool plaintext)
         }
         if (!plaintext)BRIDGE::print(F("\","), output);
         else BRIDGE::print(F("\n"), output);
-        
+
         if (!plaintext)BRIDGE::print(F("\"ssid_max_connections\":\""), output);
         else BRIDGE::print(F("Max Connections: "), output);
         BRIDGE::print(String(apconfig.max_connection).c_str(), output);
         if (!plaintext)BRIDGE::print(F("\","), output);
         else BRIDGE::print(F("\n"), output);
-        
+
         if (!plaintext)BRIDGE::print(F("\"ssid_dhcp\":\""), output);
         else BRIDGE::print(F("DHCP Server: "), output);
 #ifdef ARDUINO_ARCH_ESP32
@@ -1641,7 +1641,7 @@ void CONFIG::print_config(tpipe output, bool plaintext)
         tcpip_adapter_dhcps_get_status(TCPIP_ADAPTER_IF_AP, &dhcp_status);
         if (dhcp_status == TCPIP_ADAPTER_DHCP_STARTED)
 #else
-        if(wifi_softap_dhcps_status() == DHCP_STARTED) 
+        if(wifi_softap_dhcps_status() == DHCP_STARTED)
 #endif
         {
             BRIDGE::print(F("Started"), output);
@@ -1649,16 +1649,16 @@ void CONFIG::print_config(tpipe output, bool plaintext)
         else BRIDGE::print(F("Stopped"), output);
         if (!plaintext)BRIDGE::print(F("\","), output);
         else BRIDGE::print(F("\n"), output);
-        
+
         if (!plaintext)BRIDGE::print(F("\"ip\":\""), output);
         else BRIDGE::print(F("IP: "), output);
         BRIDGE::print(WiFi.softAPIP().toString().c_str(), output);
         if (!plaintext)BRIDGE::print(F("\","), output);
         else BRIDGE::print(F("\n"), output);
-#ifdef ARDUINO_ARCH_ESP32      
+#ifdef ARDUINO_ARCH_ESP32
         tcpip_adapter_ip_info_t ip;
         tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_AP, &ip);
-#else    
+#else
         struct ip_info ip;
         wifi_get_ip_info(SOFTAP_IF, &ip);
 #endif
@@ -1667,23 +1667,23 @@ void CONFIG::print_config(tpipe output, bool plaintext)
         BRIDGE::print(IPAddress(ip.gw.addr).toString().c_str(), output);
         if (!plaintext)BRIDGE::print(F("\","), output);
         else BRIDGE::print(F("\n"), output);
-        
+
         if (!plaintext)BRIDGE::print(F("\"msk\":\""), output);
         else BRIDGE::print(F("Mask: "), output);
         BRIDGE::print(IPAddress(ip.netmask.addr).toString().c_str(), output);
         if (!plaintext)BRIDGE::print(F("\","), output);
         else BRIDGE::print(F("\n"), output);
-        
-        
+
+
         if (!plaintext)BRIDGE::print(F("\"connected_clients\":["), output);
         else BRIDGE::print(F("Connected clients: "), output);
         int client_counter=0;
-#ifdef ARDUINO_ARCH_ESP32     
+#ifdef ARDUINO_ARCH_ESP32
         wifi_sta_list_t station;
         tcpip_adapter_sta_list_t tcpip_sta_list;
         esp_wifi_ap_get_sta_list(&station);
         tcpip_adapter_get_sta_list(&station, &tcpip_sta_list);
-#else       
+#else
         struct station_info * station;
         station = wifi_softap_get_station_info();
 #endif
@@ -1696,7 +1696,7 @@ void CONFIG::print_config(tpipe output, bool plaintext)
             if(stmp.length() > 0) {
                 if (!plaintext)stmp+=F(",");
                 else stmp+=F("\n");
-                
+
             }
             if (!plaintext)stmp+=F("{\"bssid\":\"");
             //BSSID
@@ -1734,7 +1734,7 @@ void CONFIG::print_config(tpipe output, bool plaintext)
                 //display list if any
                 if(stmp.length() > 0)BRIDGE::println(stmp.c_str(), output);
             }
-        
+
         if (!plaintext)BRIDGE::print(F("\"disabled_mode\":\""), output);
         else BRIDGE::print(F("Disabled Mode: "), output);
         BRIDGE::print(F("Station ("), output);
@@ -1742,7 +1742,7 @@ void CONFIG::print_config(tpipe output, bool plaintext)
         BRIDGE::print(F(") is disabled"), output);
         if (!plaintext)BRIDGE::print(F("\","), output);
         else BRIDGE::print(F("\n"), output);
-        
+
     } else if (WiFi.getMode() == WIFI_AP_STA) {
         BRIDGE::print(F("Mixed"), output);
         if (!plaintext)BRIDGE::print(F("\","), output);
@@ -1772,7 +1772,7 @@ void CONFIG::print_config(tpipe output, bool plaintext)
 #endif
     if (!plaintext)BRIDGE::print(F("\","), output);
     else BRIDGE::print(F("\n"), output);
-    
+
     if (!plaintext)BRIDGE::print(F("\"ssdp\":\""), output);
     else BRIDGE::print(F("SSDP: "), output);
 #ifdef SSDP_FEATURE
@@ -1782,7 +1782,7 @@ void CONFIG::print_config(tpipe output, bool plaintext)
 #endif
     if (!plaintext)BRIDGE::print(F("\","), output);
     else BRIDGE::print(F("\n"), output);
-    
+
     if (!plaintext)BRIDGE::print(F("\"netbios\":\""), output);
     else BRIDGE::print(F("NetBios: "), output);
 #ifdef NETBIOS_FEATURE
@@ -1792,7 +1792,7 @@ void CONFIG::print_config(tpipe output, bool plaintext)
 #endif
     if (!plaintext)BRIDGE::print(F("\","), output);
     else BRIDGE::print(F("\n"), output);
-    
+
     if (!plaintext)BRIDGE::print(F("\"mdns\":\""), output);
     else BRIDGE::print(F("mDNS: "), output);
 #ifdef MDNS_FEATURE
@@ -1832,7 +1832,7 @@ void CONFIG::print_config(tpipe output, bool plaintext)
 #endif
     if (!plaintext)BRIDGE::print(F("\","), output);
     else BRIDGE::print(F("\n"), output);
-    
+
     if (!plaintext)BRIDGE::print(F("\"target_fw\":\""), output);
     else BRIDGE::print(F("Target Firmware: "), output);
     BRIDGE::print(CONFIG::GetFirmwareTargetName(), output);

--- a/esp3d/config.cpp
+++ b/esp3d/config.cpp
@@ -703,10 +703,10 @@ void CONFIG::esp_restart()
     LOG("Restarting\r\n")
     ESP_SERIAL_OUT.flush();
     delay(500);
-#ifdef ARDUINO_ARCH_ESP8266
+#if defined(ARDUINO_ARCH_ESP8266) && !defined(SERIAL_SWAP)
     ESP_SERIAL_OUT.swap();
-#endif
     delay(100);
+#endif
     ESP.restart();
     while (1) {
         delay(1);
@@ -767,7 +767,7 @@ bool CONFIG::isPasswordValid(const char * password)
     }
     #if MIN_PASSWORD_LENGTH > 0
     if (strlen(password)<MIN_PASSWORD_LENGTH)) return false;
-    #endif 
+    #endif
     //no space allowed
     for (size_t i=0; i < strlen(password); i++)
         if (password[i] == ' ') {
@@ -1004,9 +1004,9 @@ bool CONFIG::write_string(int pos, const __FlashStringHelper *str)
     return write_string(pos,stmp.c_str());
 }
 
-bool CONFIG::check_update_presence( ){ 
+bool CONFIG::check_update_presence( ){
      bool result = false;
-     if (CONFIG::is_direct_sd) { 
+     if (CONFIG::is_direct_sd) {
          long baud_rate=0;
          if (!CONFIG::read_buffer(EP_BAUD_RATE,  (byte *)&baud_rate, INTEGER_LENGTH)) return false;
          if (ESP_SERIAL_OUT.baudRate() != baud_rate)ESP_SERIAL_OUT.begin(baud_rate);

--- a/esp3d/config.cpp
+++ b/esp3d/config.cpp
@@ -1329,7 +1329,7 @@ void CONFIG::print_config(tpipe output, bool plaintext)
 #ifdef ARDUINO_ARCH_ESP8266
     BRIDGE::print(String(ESP.getChipId()).c_str(), output);
 #else
-	BRIDGE::print(String((uint16_t)(ESP.getEfuseMac()>>32)).c_str(), output);
+    BRIDGE::print(String((uint16_t)(ESP.getEfuseMac()>>32)).c_str(), output);
 #endif
     if (!plaintext)BRIDGE::print(F("\","), output);
     else BRIDGE::print(F("\n"), output);
@@ -1388,7 +1388,7 @@ void CONFIG::print_config(tpipe output, bool plaintext)
     if (!plaintext)BRIDGE::print(F("\","), output);
     else BRIDGE::print(F("\n"), output);
 #else 
-	if (!plaintext)BRIDGE::print(F("\"update_size\":\""), output);
+    if (!plaintext)BRIDGE::print(F("\"update_size\":\""), output);
     else BRIDGE::print(F("Available Size for update: "), output);
     uint32_t  flashsize = ESP.getFlashChipSize();
 //Not OTA on 2Mb board per spec
@@ -1539,8 +1539,8 @@ void CONFIG::print_config(tpipe output, bool plaintext)
         if (wifi_station_dhcpc_status()==DHCP_STARTED) 
 #endif
         {
-			BRIDGE::print(F("DHCP"), output);
-		}
+            BRIDGE::print(F("DHCP"), output);
+        }
         else BRIDGE::print(F("Static"), output);
          if (!plaintext)BRIDGE::print(F("\","), output);
         else BRIDGE::print(F("\n"), output);
@@ -1601,7 +1601,7 @@ void CONFIG::print_config(tpipe output, bool plaintext)
 #ifdef ARDUINO_ARCH_ESP32
         BRIDGE::print((const char*)conf.ap.ssid, output);
 #else
-		BRIDGE::print((const char*)apconfig.ssid, output);
+        BRIDGE::print((const char*)apconfig.ssid, output);
 #endif
         if (!plaintext)BRIDGE::print(F("\","), output);
         else BRIDGE::print(F("\n"), output);
@@ -1644,8 +1644,8 @@ void CONFIG::print_config(tpipe output, bool plaintext)
         if(wifi_softap_dhcps_status() == DHCP_STARTED) 
 #endif
         {
-			BRIDGE::print(F("Started"), output);
-		}
+            BRIDGE::print(F("Started"), output);
+        }
         else BRIDGE::print(F("Stopped"), output);
         if (!plaintext)BRIDGE::print(F("\","), output);
         else BRIDGE::print(F("\n"), output);
@@ -1703,7 +1703,7 @@ void CONFIG::print_config(tpipe output, bool plaintext)
 #ifdef ARDUINO_ARCH_ESP32
             stmp += CONFIG::mac2str(tcpip_sta_list.sta[i].mac);
 #else
-			stmp += CONFIG::mac2str(station->bssid);
+            stmp += CONFIG::mac2str(station->bssid);
 #endif
             if (!plaintext)stmp+=F("\",\"ip\":\"");
             else stmp += F(" ");
@@ -1711,16 +1711,16 @@ void CONFIG::print_config(tpipe output, bool plaintext)
 #ifdef ARDUINO_ARCH_ESP32
             stmp += IPAddress(tcpip_sta_list.sta[i].ip.addr).toString().c_str();
 #else
-			stmp += IPAddress((const uint8_t *)&station->ip).toString().c_str();
+            stmp += IPAddress((const uint8_t *)&station->ip).toString().c_str();
 #endif
             if (!plaintext)stmp+=F("\"}");
             //increment counter
             client_counter++;
 #ifdef ARDUINO_ARCH_ESP32
-		}
+        }
 #else
             //go next record
-            station =STAILQ_NEXT(station,	next);
+            station =STAILQ_NEXT(station, next);
         }
         wifi_softap_free_station_info();
 #endif

--- a/esp3d/config.h
+++ b/esp3d/config.h
@@ -168,8 +168,6 @@
 #endif
 #ifdef DEBUG_OUTPUT_SERIAL
 #ifdef SERIAL_SWAP
-#include <SoftwareSerial.h>
-extern SoftwareSerial* SwSerial;
 #define LOG(string) {ESP_SWSERIAL_OUT.print(string);}
 #define DEBUG_PIPE SWSERIAL_PIPE
 #else
@@ -185,6 +183,11 @@ extern SoftwareSerial* SwSerial;
 #else
 #define LOG(string) {}
 #define DEBUG_PIPE NO_PIPE
+#endif
+
+#ifdef SERIAL_SWAP
+#include <SoftwareSerial.h>
+extern SoftwareSerial* SwSerial;
 #endif
 
 #ifndef CONFIG_h

--- a/esp3d/config.h
+++ b/esp3d/config.h
@@ -177,7 +177,7 @@
 #endif
 #ifdef DEBUG_OUTPUT_TCP
 #include "bridge.h"
-#define LOG(string) {BRIDGE::send2TCP(string);}
+#define LOG(string) {BRIDGE::send2TCP(string, true);}
 #define DEBUG_PIPE TCP_PIPE
 #endif
 #else
@@ -308,6 +308,7 @@ const char M117_[] PROGMEM =		"M117 ";
 #define DEFAULT_BEACON_INTERVAL			100
 const int DEFAULT_WEB_PORT =			80;
 const int DEFAULT_DATA_PORT =			8888;
+const int DEFAULT_DEBUG_PORT =			8889;
 #define DEFAULT_REFRESH_PAGE_TIME			3
 const int  DEFAULT_XY_FEEDRATE=1000;
 const int  DEFAULT_Z_FEEDRATE	=100;

--- a/esp3d/config.h
+++ b/esp3d/config.h
@@ -213,7 +213,7 @@ typedef enum {
     WEB_PIPE = 5,
 #ifdef SERIAL_SWAP
     SWSERIAL_PIPE = 6,
-#endif    
+#endif
 } tpipe;
 
 typedef enum {
@@ -270,7 +270,7 @@ typedef enum {
 #define EP_TARGET_FW		461 //1  bytes = flag
 #define EP_TIMEZONE         462//1  bytes = flag
 #define EP_TIME_ISDST       463//1  bytes = flag
-#define EP_TIME_SERVER1 464//129 bytes 128+1 = string  ; warning does not support multibyte char like chinese  
+#define EP_TIME_SERVER1 464//129 bytes 128+1 = string  ; warning does not support multibyte char like chinese
 #define EP_TIME_SERVER2  593 //129 bytes 128+1 = string  ; warning does not support multibyte char like chinese
 #define EP_TIME_SERVER3  722 //129 bytes 128+1 = string  ; warning does not support multibyte char like chinese
 #define EP_IS_DIRECT_SD   850//1  bytes = flag

--- a/esp3d/esp3d.ino
+++ b/esp3d/esp3d.ino
@@ -79,7 +79,7 @@ extern DNSServer dnsServer;
 void setup()
 {
     bool breset_config=false;
-    bool directsd_check = false;
+    // unused: bool directsd_check = false;
     web_interface = NULL;
 #ifdef TCP_IP_DATA_FEATURE
     data_server = NULL;

--- a/esp3d/esp3d.ino
+++ b/esp3d/esp3d.ino
@@ -76,7 +76,7 @@ extern DNSServer dnsServer;
 #endif
 #include <FS.h>
 
-#if defined(DEBUG_ESP3D) && defined(SERIAL_SWAP)
+#if defined(SERIAL_SWAP)
 SoftwareSerial* SwSerial = nullptr;
 #endif
 

--- a/esp3d/esp3d.ino
+++ b/esp3d/esp3d.ino
@@ -76,6 +76,10 @@ extern DNSServer dnsServer;
 #endif
 #include <FS.h>
 
+#if defined(DEBUG_ESP3D) && defined(SERIAL_SWAP)
+SoftwareSerial* SwSerial = nullptr;
+#endif
+
 void setup()
 {
     bool breset_config=false;
@@ -85,10 +89,24 @@ void setup()
     data_server = NULL;
 #endif
     // init:
+#ifdef SERIAL_SWAP
+    Serial.begin(DEFAULT_BAUD_RATE); // needed for swap
+    Serial.swap();
+#endif
 #ifdef DEBUG_ESP3D
+#ifdef SERIAL_SWAP
+    (SwSerial = new SoftwareSerial(-1 /* transmit not needed - was:3 */, /* receive */1))->begin(DEFAULT_BAUD_RATE);
+    LOG("\r\nHardwareSerial for Printer is now on GPIO15 (TX) and GPIO13 (RX)");
+#endif
     if (ESP_SERIAL_OUT.baudRate() != DEFAULT_BAUD_RATE)ESP_SERIAL_OUT.begin(DEFAULT_BAUD_RATE);
     delay(2000);
+#ifdef SERIAL_SWAP
     LOG("\r\nDebug Serial set\r\n")
+    ESP_SERIAL_OUT.println("M117 hardware serial here");
+    ESP_SWSERIAL_OUT.println("software serial here 1/2");
+    LOG("software serial here 2/2\r\n");
+    delay(2000);
+#endif
 #endif
     //WiFi.disconnect();
     WiFi.mode(WIFI_OFF);

--- a/esp3d/storestrings.cpp
+++ b/esp3d/storestrings.cpp
@@ -83,7 +83,7 @@ bool STORESTRINGS_CLASS::add (const char * string)
     //get size including \0 at the end
     size_t size = strlen(string)+1;
     bool need_resize=false;
-    if ( (_maxstringlength!=-1) && (size >_maxstringlength+1 )) {
+    if ( (_maxstringlength!=-1) && ((int)size >_maxstringlength+1 )) {
         need_resize = true;
         size=_maxstringlength+1;
     }

--- a/esp3d/webinterface.cpp
+++ b/esp3d/webinterface.cpp
@@ -77,7 +77,7 @@ void handle_web_interface_root()
         if(SPIFFS.exists(pathWithGz)) {
             path = pathWithGz;
         }
-		FS_FILE file = SPIFFS.open(path, SPIFFS_FILE_READ);
+        FS_FILE file = SPIFFS.open(path, SPIFFS_FILE_READ);
         web_interface->web_server.streamFile(file, contentType);
         file.close();
         return;
@@ -163,7 +163,7 @@ void SPIFFSFileupload()
 #ifdef ARDUINO_ARCH_ESP8266
         web_interface->web_server.client().stopAll();
 #else 
-		web_interface->web_server.client().stop();
+        web_interface->web_server.client().stop();
 #endif
         return;
     }
@@ -187,7 +187,7 @@ void SPIFFSFileupload()
         }
         ESP_SERIAL_OUT.println("M117 Start ESP upload");
         //create file
-		web_interface->fsUploadFile = SPIFFS.open(filename, SPIFFS_FILE_WRITE);
+        web_interface->fsUploadFile = SPIFFS.open(filename, SPIFFS_FILE_WRITE);
         //check If creation succeed
         if (web_interface->fsUploadFile) {
             //if yes upload is started
@@ -197,9 +197,9 @@ void SPIFFSFileupload()
             web_interface->_upload_status=UPLOAD_STATUS_CANCELLED;
             ESP_SERIAL_OUT.println("M117 Error ESP create");
 #ifdef ARDUINO_ARCH_ESP8266
-			web_interface->web_server.client().stopAll();
+            web_interface->web_server.client().stopAll();
 #else 
-			web_interface->web_server.client().stop();
+            web_interface->web_server.client().stop();
 #endif
         }
         //Upload write
@@ -220,9 +220,9 @@ void SPIFFSFileupload()
             //we have a problem set flag UPLOAD_STATUS_CANCELLED
             web_interface->_upload_status=UPLOAD_STATUS_CANCELLED;
 #ifdef ARDUINO_ARCH_ESP8266
-			web_interface->web_server.client().stopAll();
+            web_interface->web_server.client().stopAll();
 #else 
-			web_interface->web_server.client().stop();
+            web_interface->web_server.client().stop();
 #endif
             ESP_SERIAL_OUT.println("M117 Error ESP write");
         }
@@ -245,9 +245,9 @@ void SPIFFSFileupload()
             //we have a problem set flag UPLOAD_STATUS_CANCELLED
             web_interface->_upload_status=UPLOAD_STATUS_CANCELLED;
 #ifdef ARDUINO_ARCH_ESP8266
-			web_interface->web_server.client().stopAll();
+            web_interface->web_server.client().stopAll();
 #else 
-			web_interface->web_server.client().stop();
+            web_interface->web_server.client().stop();
 #endif
             SPIFFS.remove(filename);
             ESP_SERIAL_OUT.println("M117 Error ESP close");
@@ -255,8 +255,8 @@ void SPIFFSFileupload()
         //Upload cancelled
         //**************
     } else {
-			ESP_SERIAL_OUT.println("M117 Error ESP close");
-			return;
+            ESP_SERIAL_OUT.println("M117 Error ESP close");
+            return;
         web_interface->_upload_status=UPLOAD_STATUS_CANCELLED;
         SPIFFS.remove(filename);
         ESP_SERIAL_OUT.println("M117 Error ESP upload");
@@ -615,7 +615,7 @@ void WebUpdateUpload()
 #ifdef ARDUINO_ARCH_ESP8266
         web_interface->web_server.client().stopAll();
 #else 
-		web_interface->web_server.client().stop();
+        web_interface->web_server.client().stop();
 #endif
         ESP_SERIAL_OUT.println("M117 Update failed");
         LOG("SD Update failed\r\n");
@@ -629,13 +629,13 @@ void WebUpdateUpload()
         ESP_SERIAL_OUT.println(F("M117 Update Firmware"));
         web_interface->_upload_status= UPLOAD_STATUS_ONGOING;
 #ifdef ARDUINO_ARCH_ESP8266
-		WiFiUDP::stopAll();
+        WiFiUDP::stopAll();
 #endif
 #ifdef ARDUINO_ARCH_ESP8266
                 maxSketchSpace = (ESP.getFreeSketchSpace() - 0x1000) & 0xFFFFF000;
 #else 
 //Not sure can do OTA on 2Mb board
-				maxSketchSpace = (ESP.getFlashChipSize()>0x20000)?0x140000:0x140000/2;
+                maxSketchSpace = (ESP.getFlashChipSize()>0x20000)?0x140000:0x140000/2;
 #endif
         last_upload_update = 0;
         if(!Update.begin(maxSketchSpace)) { //start with max available size
@@ -682,7 +682,7 @@ void handleUpdate()
 {
     level_authenticate_type auth_level = web_interface->is_authenticated();
     if (auth_level != LEVEL_ADMIN) {
-		web_interface->_upload_status=UPLOAD_STATUS_NONE;
+        web_interface->_upload_status=UPLOAD_STATUS_NONE;
         web_interface->web_server.send(403,"text/plain","Not allowed, log in first!\n");
         return;
     }
@@ -750,10 +750,10 @@ void handleFileList()
                     FS_DIR dir = SPIFFS.openDir(path);
                     if (!dir.next()) {
 #else
-					String ptmp = path;
-					if ((path != "/") && (path[path.length()-1]='/'))ptmp = path.substring(0,path.length()-1);
-					FS_FILE dir = SPIFFS.open(ptmp);
-					FS_FILE dircontent = dir.openNextFile();
+                    String ptmp = path;
+                    if ((path != "/") && (path[path.length()-1]='/'))ptmp = path.substring(0,path.length()-1);
+                    FS_FILE dir = SPIFFS.open(ptmp);
+                    FS_FILE dircontent = dir.openNextFile();
                     if (!dircontent) {
 #endif
                         //keep directory alive even empty
@@ -783,15 +783,15 @@ void handleFileList()
                 {
                     while (dir.next()) {
 #else
-				FS_FILE dir = SPIFFS.open(path + shortname);
+                FS_FILE dir = SPIFFS.open(path + shortname);
                 {
-					FS_FILE file2deleted = dir.openNextFile();
+                    FS_FILE file2deleted = dir.openNextFile();
                     while (file2deleted) {
 #endif
 #ifdef ARDUINO_ARCH_ESP8266
                         String fullpath = dir.fileName();
 #else
-						String fullpath = file2deleted.name();
+                        String fullpath = file2deleted.name();
 #endif
                         if (!SPIFFS.remove(fullpath)) {
                             delete_error = true;
@@ -834,9 +834,9 @@ void handleFileList()
 #ifdef ARDUINO_ARCH_ESP8266
     FS_DIR dir = SPIFFS.openDir(path);
 #else
-	String ptmp = path;
-	if ((path != "/") && (path[path.length()-1]='/'))ptmp = path.substring(0,path.length()-1);
-	FS_FILE dir = SPIFFS.open(ptmp);
+    String ptmp = path;
+    if ((path != "/") && (path[path.length()-1]='/'))ptmp = path.substring(0,path.length()-1);
+    FS_FILE dir = SPIFFS.open(ptmp);
 #endif
     jsonfile+="\"files\":[";
     bool firstentry=true;
@@ -845,8 +845,8 @@ void handleFileList()
     while (dir.next()) {
         String filename = dir.fileName();
 #else
-	File fileparsed = dir.openNextFile();
-	while (fileparsed) {
+    File fileparsed = dir.openNextFile();
+    while (fileparsed) {
         String filename = fileparsed.name();
 #endif
         String size ="";
@@ -876,7 +876,7 @@ void handleFileList()
 #ifdef ARDUINO_ARCH_ESP8266
                 size = CONFIG::formatBytes(dir.fileSize());
 #else
-				size = CONFIG::formatBytes(fileparsed.size());
+                size = CONFIG::formatBytes(fileparsed.size());
 #endif
                 
             } else {
@@ -912,7 +912,7 @@ void handleFileList()
     totalBytes = info.totalBytes;
     usedBytes = info.usedBytes;
 #else
-	totalBytes = SPIFFS.totalBytes();
+    totalBytes = SPIFFS.totalBytes();
     usedBytes = SPIFFS.usedBytes();
 #endif
     jsonfile+="\"total\":\"" + CONFIG::formatBytes(totalBytes) + "\",";

--- a/esp3d/webinterface.cpp
+++ b/esp3d/webinterface.cpp
@@ -374,7 +374,7 @@ void SDFile_serial_upload()
         filesize+=upload.currentSize;
         uint32_t startwrite = millis();
 #endif
-        for (int pos = 0; pos < upload.currentSize; pos++) { //parse full post data
+        for (int pos = 0; pos < (int)upload.currentSize; pos++) { //parse full post data
             if (buffer_size < MAX_RESEND_BUFFER-1) { //raise error/handle if overbuffer - copy is space available
                 //remove/ignore every comment to save transfert time and avoid over buffer issues
                 if (upload.buf[pos] == ';') {
@@ -1262,7 +1262,7 @@ void handle_web_command()
                 return;
             }
             //is there space for parameters?
-            if (ESPpos2<cmd.length()) {
+            if (ESPpos2<(int)cmd.length()) {
                 cmd_part2=cmd.substring(ESPpos2+1);
             }
             //if command is a valid number then execute command
@@ -1456,7 +1456,7 @@ void handle_web_command_silent()
             String cmd_part1=cmd.substring(ESPpos+4,ESPpos2);
             String cmd_part2="";
             //is there space for parameters?
-            if (ESPpos2<cmd.length()) {
+            if (ESPpos2<(int)cmd.length()) {
                 cmd_part2=cmd.substring(ESPpos2+1);
             }
             //if command is a valid number then execute command

--- a/esp3d/webinterface.cpp
+++ b/esp3d/webinterface.cpp
@@ -162,13 +162,13 @@ void SPIFFSFileupload()
         ESP_SERIAL_OUT.println("M117 Error ESP upload");
 #ifdef ARDUINO_ARCH_ESP8266
         web_interface->web_server.client().stopAll();
-#else 
+#else
         web_interface->web_server.client().stop();
 #endif
         return;
     }
 
-    static String filename;    
+    static String filename;
     //get current file ID
     HTTPUpload& upload = (web_interface->web_server).upload();
     //Upload start
@@ -198,7 +198,7 @@ void SPIFFSFileupload()
             ESP_SERIAL_OUT.println("M117 Error ESP create");
 #ifdef ARDUINO_ARCH_ESP8266
             web_interface->web_server.client().stopAll();
-#else 
+#else
             web_interface->web_server.client().stop();
 #endif
         }
@@ -221,7 +221,7 @@ void SPIFFSFileupload()
             web_interface->_upload_status=UPLOAD_STATUS_CANCELLED;
 #ifdef ARDUINO_ARCH_ESP8266
             web_interface->web_server.client().stopAll();
-#else 
+#else
             web_interface->web_server.client().stop();
 #endif
             ESP_SERIAL_OUT.println("M117 Error ESP write");
@@ -246,7 +246,7 @@ void SPIFFSFileupload()
             web_interface->_upload_status=UPLOAD_STATUS_CANCELLED;
 #ifdef ARDUINO_ARCH_ESP8266
             web_interface->web_server.client().stopAll();
-#else 
+#else
             web_interface->web_server.client().stop();
 #endif
             SPIFFS.remove(filename);
@@ -567,7 +567,7 @@ void SDFile_serial_upload()
                 //web_interface->web_server.client().stopAll();
                  LOG("Need to stop");
                 client_closed = true;
-            }   
+            }
             filename = "M30 " + filename;
             ESP_SERIAL_OUT.println(filename);
             ESP_SERIAL_OUT.println("M117 SD upload failed");
@@ -614,7 +614,7 @@ void WebUpdateUpload()
         web_interface->_upload_status=UPLOAD_STATUS_CANCELLED;
 #ifdef ARDUINO_ARCH_ESP8266
         web_interface->web_server.client().stopAll();
-#else 
+#else
         web_interface->web_server.client().stop();
 #endif
         ESP_SERIAL_OUT.println("M117 Update failed");
@@ -633,7 +633,7 @@ void WebUpdateUpload()
 #endif
 #ifdef ARDUINO_ARCH_ESP8266
                 maxSketchSpace = (ESP.getFreeSketchSpace() - 0x1000) & 0xFFFFF000;
-#else 
+#else
 //Not sure can do OTA on 2Mb board
                 maxSketchSpace = (ESP.getFlashChipSize()>0x20000)?0x140000:0x140000/2;
 #endif
@@ -798,7 +798,7 @@ void handleFileList()
                             status = F("Cannot deleted ") ;
                             status+=fullpath;
                         }
-#ifdef ARDUINO_ARCH_ESP32     
+#ifdef ARDUINO_ARCH_ESP32
                      file2deleted = dir.openNextFile();
 #endif
                     }
@@ -878,7 +878,7 @@ void handleFileList()
 #else
                 size = CONFIG::formatBytes(fileparsed.size());
 #endif
-                
+
             } else {
                 addtolist = false;
             }
@@ -1026,7 +1026,7 @@ void handle_not_found()
             FS_FILE file = SPIFFS.open(path, SPIFFS_FILE_READ);
             web_interface->web_server.streamFile(file, contentType);
             file.close();
-           
+
         } else {
             //if not template use default page
             contentType=FPSTR(PAGE_404);
@@ -1075,13 +1075,13 @@ void handle_login()
         //web_interface->web_server.client().stop();
         return;
     }
-    
+
     level_authenticate_type auth_level= web_interface->is_authenticated();
    if (auth_level == LEVEL_GUEST) auths = F("guest");
     else if (auth_level == LEVEL_USER) auths = F("user");
     else if (auth_level == LEVEL_ADMIN) auths = F("admin");
     else auths = F("???");
-        
+
     //check is it is a submission or a query
     if (web_interface->web_server.hasArg("SUBMIT")) {
         //is there a correct list of query?
@@ -1156,7 +1156,7 @@ void handle_login()
             strcpy(current_auth->userID,sUser.c_str());
             current_auth->last_time=millis();
             if (web_interface->AddAuthIP(current_auth)) {
-                String tmps ="ESPSESSIONID="; 
+                String tmps ="ESPSESSIONID=";
                 tmps+=current_auth->sessionID;
                 web_interface->web_server.sendHeader("Set-Cookie",tmps);
                 web_interface->web_server.sendHeader("Cache-Control","no-cache");
@@ -1177,9 +1177,9 @@ void handle_login()
                 smsg = F("Error: Too many connections");
             }
         }
-   } 
+   }
     if (code == 200) smsg = F("Ok");
-    
+
     //build  JSON
     String buffer2send = "{\"status\":\"" + smsg + "\",\"authentication_lvl\":\"";
     buffer2send += auths;
@@ -1515,7 +1515,7 @@ WEBINTERFACE_CLASS::WEBINTERFACE_CLASS (int port):web_server(port)
 #ifdef CAPTIVE_PORTAL_FEATURE
     web_server.on("/generate_204",HTTP_ANY, handle_web_interface_root);
     web_server.on("/gconnectivitycheck.gstatic.com",HTTP_ANY, handle_web_interface_root);
-    //do not forget the / at the end 
+    //do not forget the / at the end
     web_server.on("/fwlink/",HTTP_ANY, handle_web_interface_root);
 #endif
     web_server.onNotFound( handle_not_found);

--- a/esp3d/webinterface.h
+++ b/esp3d/webinterface.h
@@ -55,7 +55,7 @@ public:
 #ifdef ARDUINO_ARCH_ESP8266
     ESP8266WebServer web_server;
 #else
-	WebServer web_server;
+    WebServer web_server;
 #endif
      FS_FILE fsUploadFile;
 #ifdef ERROR_MSG_FEATURE

--- a/esp3d/wificonf.cpp
+++ b/esp3d/wificonf.cpp
@@ -86,11 +86,11 @@ int32_t WIFI_CONFIG::getSignal(int32_t RSSI)
 
 const char * WIFI_CONFIG::get_hostname()
 {
-	String hname;
+    String hname;
 #ifdef ARDUINO_ARCH_ESP8266
-	hname = WiFi.hostname();
+    hname = WiFi.hostname();
 #else
-	hname = WiFi.getHostname();
+    hname = WiFi.getHostname();
 #endif
     if (hname.length()==0) {
         if (!CONFIG::read_string(EP_HOSTNAME, _hostname, MAX_HOSTNAME_LENGTH)) {
@@ -235,7 +235,7 @@ bool WIFI_CONFIG::Setup(bool force_ap)
             return false;
         }
 #ifdef ARDUINO_ARCH_ESP32
-		esp_wifi_set_protocol(ESP_IF_WIFI_AP, bflag);
+        esp_wifi_set_protocol(ESP_IF_WIFI_AP, bflag);
 #endif
         LOG("Set AP\r\n")
         //setup Soft AP
@@ -261,7 +261,7 @@ bool WIFI_CONFIG::Setup(bool force_ap)
             return false;
         }
 #ifdef ARDUINO_ARCH_ESP32
-		conf.ap.channel=bflag;
+        conf.ap.channel=bflag;
 #else
         apconfig.channel=bflag;
 #endif
@@ -270,7 +270,7 @@ bool WIFI_CONFIG::Setup(bool force_ap)
             return false;
         }
 #ifdef ARDUINO_ARCH_ESP32
-		conf.ap.authmode=(wifi_auth_mode_t)bflag;
+        conf.ap.authmode=(wifi_auth_mode_t)bflag;
 #else
         apconfig.authmode=(AUTH_MODE)bflag;
 #endif
@@ -279,14 +279,14 @@ bool WIFI_CONFIG::Setup(bool force_ap)
             return false;
         }
 #ifdef ARDUINO_ARCH_ESP32
-		conf.ap.ssid_hidden=!bflag;
+        conf.ap.ssid_hidden=!bflag;
 #else
         apconfig.ssid_hidden=!bflag;
 #endif
         
         //no need to add these settings to configuration just use default ones
 #ifdef ARDUINO_ARCH_ESP32
-		conf.ap.max_connection=DEFAULT_MAX_CONNECTIONS;
+        conf.ap.max_connection=DEFAULT_MAX_CONNECTIONS;
         conf.ap.beacon_interval=DEFAULT_BEACON_INTERVAL;
         if (esp_wifi_set_config(ESP_IF_WIFI_AP, &conf)!=ESP_OK){
             ESP_SERIAL_OUT.println(F("M117 Error Wifi AP!"));
@@ -345,7 +345,7 @@ bool WIFI_CONFIG::Setup(bool force_ap)
             return false;
         }
 #ifdef ARDUINO_ARCH_ESP32
-		esp_wifi_set_protocol(ESP_IF_WIFI_STA, bflag);
+        esp_wifi_set_protocol(ESP_IF_WIFI_STA, bflag);
 #endif
         //setup station mode
         WiFi.mode(WIFI_STA);
@@ -394,7 +394,7 @@ bool WIFI_CONFIG::Setup(bool force_ap)
 #ifdef ARDUINO_ARCH_ESP8266
         WiFi.hostname(hostname);
 #else
-		WiFi.setHostname(hostname);
+        WiFi.setHostname(hostname);
 #endif
     }
 
@@ -439,20 +439,20 @@ bool WIFI_CONFIG::Enable_servers()
     // Set up mDNS responder:
     //useless in AP mode and service consuming 
     if (WiFi.getMode()!=WIFI_AP ){
-		char hostname [MAX_HOSTNAME_LENGTH+1];
-		if (!CONFIG::read_string(EP_HOSTNAME, hostname, MAX_HOSTNAME_LENGTH)) {
-			strcpy(hostname,get_default_hostname());
-		}
-		if (!mdns.begin(hostname)) {
-        ESP_SERIAL_OUT.print(FPSTR(M117_));
-        ESP_SERIAL_OUT.println(F("Error with mDNS!"));
-        delay(1000);
-		} else {
-		// Check for any mDNS queries and send responses
-		delay(100);
-		wifi_config.mdns.addService("http", "tcp", wifi_config.iweb_port);
-		}
-	}
+        char hostname [MAX_HOSTNAME_LENGTH+1];
+        if (!CONFIG::read_string(EP_HOSTNAME, hostname, MAX_HOSTNAME_LENGTH)) {
+            strcpy(hostname,get_default_hostname());
+        }
+        if (!mdns.begin(hostname)) {
+            ESP_SERIAL_OUT.print(FPSTR(M117_));
+            ESP_SERIAL_OUT.println(F("Error with mDNS!"));
+            delay(1000);
+        } else {
+            // Check for any mDNS queries and send responses
+            delay(100);
+            wifi_config.mdns.addService("http", "tcp", wifi_config.iweb_port);
+        }
+    }
 #endif
 #if defined(SSDP_FEATURE) || defined(NETBIOS_FEATURE)
     String shost;

--- a/esp3d/wificonf.cpp
+++ b/esp3d/wificonf.cpp
@@ -156,7 +156,7 @@ bool WIFI_CONFIG::Setup(bool force_ap)
     }
 #ifdef ARDUINO_ARCH_ESP8266
     WiFi.setSleepMode ((WiFiSleepType_t)bflag);
-#else 
+#else
     esp_wifi_set_ps((wifi_ps_type_t)bflag);
 #endif
     sleep_mode=bflag;
@@ -296,7 +296,7 @@ bool WIFI_CONFIG::Setup(bool force_ap)
 #else
         apconfig.ssid_hidden=!bflag;
 #endif
-        
+
         //no need to add these settings to configuration just use default ones
 #ifdef ARDUINO_ARCH_ESP32
         conf.ap.max_connection=DEFAULT_MAX_CONNECTIONS;
@@ -393,7 +393,7 @@ bool WIFI_CONFIG::Setup(bool force_ap)
                 //for smoothieware to keep position
                 for (byte i= 0;i< 4-dot; i++)msg +=F(" ");
                 if (dot == 4)dot=0;
-                ESP_SERIAL_OUT.println(msg); 
+                ESP_SERIAL_OUT.println(msg);
                 break;
             }
             delay(500);
@@ -450,7 +450,7 @@ bool WIFI_CONFIG::Enable_servers()
 
 #ifdef MDNS_FEATURE
     // Set up mDNS responder:
-    //useless in AP mode and service consuming 
+    //useless in AP mode and service consuming
     if (WiFi.getMode()!=WIFI_AP ){
         char hostname [MAX_HOSTNAME_LENGTH+1];
         if (!CONFIG::read_string(EP_HOSTNAME, hostname, MAX_HOSTNAME_LENGTH)) {
@@ -490,7 +490,7 @@ bool WIFI_CONFIG::Enable_servers()
     if (WiFi.getMode()!=WIFI_AP )SSDP.begin();
 #endif
 #ifdef NETBIOS_FEATURE
-    //useless in AP mode and service consuming 
+    //useless in AP mode and service consuming
     if (WiFi.getMode()!=WIFI_AP )NBNS.begin(shost.c_str());
 #endif
 
@@ -508,7 +508,7 @@ bool WIFI_CONFIG::Disable_servers()
     }
 #endif
 #ifdef NETBIOS_FEATURE
-    //useless in AP mode and service consuming 
+    //useless in AP mode and service consuming
     if (WiFi.getMode()!=WIFI_AP )NBNS.end();
 #endif
     web_interface->web_server.stop();

--- a/esp3d/wificonf.cpp
+++ b/esp3d/wificonf.cpp
@@ -22,6 +22,8 @@
 #include "bridge.h"
 #include "webinterface.h"
 
+#include "lwip/init.h" // LWIP_VERSION_MAJOR definition
+
 #ifdef ARDUINO_ARCH_ESP8266
 #include "ESP8266WiFi.h"
 #ifdef MDNS_FEATURE
@@ -185,6 +187,16 @@ bool WIFI_CONFIG::Setup(bool force_ap)
         LOG("SSID ")
         LOG(sbuf)
         LOG("\r\n")
+
+#ifndef LWIP_VERSION_MAJOR
+#error
+#endif
+#if defined(ARDUINO_ARCH_ESP32) || LWIP_VERSION_MAJOR == 1
+
+// the code below does not work for esp8266/lwip2
+// Beside, there's no real point changing IP address in AP mode
+// the default IP address to use in wifi clients will be 192.168.4.1
+
         //DHCP or Static IP ?
         if (!CONFIG::read_byte(EP_AP_IP_MODE, &bflag )) {
             LOG("Error IP mode\r\n")
@@ -226,6 +238,7 @@ bool WIFI_CONFIG::Setup(bool force_ap)
             WiFi.softAPConfig( local_ip,  gateway,  subnet);
             delay(100);
         }
+#endif // no static IP configuration in esp8266 AP mode
         LOG("Disable STA\r\n")
         WiFi.enableSTA(false);
         delay(100);

--- a/esp3d/wificonf.cpp
+++ b/esp3d/wificonf.cpp
@@ -70,6 +70,7 @@ WIFI_CONFIG::WIFI_CONFIG()
 {
     iweb_port=DEFAULT_WEB_PORT;
     idata_port=DEFAULT_DATA_PORT;
+    idebug_port=DEFAULT_DEBUG_PORT;
     baud_rate=DEFAULT_BAUD_RATE;
     sleep_mode=DEFAULT_SLEEP_MODE;
     _hostname[0]=0;
@@ -446,6 +447,11 @@ bool WIFI_CONFIG::Enable_servers()
     data_server = new WiFiServer (wifi_config.idata_port);
     data_server->begin();
     data_server->setNoDelay(true);
+#if defined(DEBUG_ESP3D) && defined(DEBUG_OUTPUT_TCP)
+    debug_server = new WiFiServer (wifi_config.idebug_port);
+    debug_server->begin();
+    debug_server->setNoDelay(false);
+#endif
 #endif
 
 #ifdef MDNS_FEATURE

--- a/esp3d/wificonf.h
+++ b/esp3d/wificonf.h
@@ -45,6 +45,7 @@ public:
     WIFI_CONFIG();
     int iweb_port;
     int idata_port;
+    int idebug_port;
     long baud_rate;
     int sleep_mode;
     int32_t getSignal(int32_t RSSI);


### PR DESCRIPTION

*edit2:* tcp debug server while printing, on default port 8889 (when debug on tcp is enabled)

option `SERIAL_SWAP` to enable in `config.h`:
- **no more serial garbage** (at boot or on failure) by using Hardware serial on GPIO13/15 for printer
- allow debugging on serial via USB while printing (using software serial output)

also,
- when using esp8266 arduino core 2.4.2 and git master, let default AP IP address (then it works)

and,
- fixed compilation warnings
- convert tabs to spaces
- remove trailing spaces

Note:
This is not tested on my printer yet (emotion-tech / microdelta-rework / repetier),
but an USB/serial converter on GPIO13/15 shows only G-codes while my arduino
serial console shows all debugs messages (and serial garbage at boot time).

*edit*:
Maybe for reviewing it is better to check commits one by one.
Sorry for putting all of this in one PR (I can propose multiple PR is desired)