### PR TITLE
Add serial_service.readBytes in wait_for_ack

### DIFF
--- a/esp3d/src/modules/gcode_host/gcode_host.cpp
+++ b/esp3d/src/modules/gcode_host/gcode_host.cpp
@@ -112,6 +112,7 @@ bool GcodeHost::wait_for_ack(uint32_t timeout, bool checksum, const char * ack)
         size_t len = serial_service.available();
         if (len > 0) {
             uint8_t * sbuf = (uint8_t *)malloc(len+1);
+            serial_service.readBytes(sbuf, len);
             if(!sbuf) {
                 _error = ERROR_MEMORY_PROBLEM;
                 return false;


### PR DESCRIPTION
Maybe this is a bug:)

Thanks for your great work.

I am an engineer from Rotrics, a company that creates desktop robotic arms, this is our official website: [https://www.rotrics.com/](url)
We have a TouchScreen accessory based on ESP32/ESP-ADF/LVGL, and I am trying to port ESP-3D to it. I am trying these features: send gcode file from direct sdcard & 3.5TFT LVGL.

Thanks again for your great work. I hope I can contribute more to this project in the future.