### PR TITLE
INHIBIT_NETCONFIG_ONBOOT

### DIFF
--- a/esp3d/configuration.h
+++ b/esp3d/configuration.h
@@ -51,6 +51,9 @@
 //ETH_FEATURE : enable Ethernet function
 //#define ETH_FEATURE
 
+//INHIBIT_NETCONFIG_ONBOOT : don't start networking on boot
+//#define INHIBIT_NETCONFIG_ONBOOT
+
 //BLUETOOTH_FEATURE : enable BT Serial function
 //#define BLUETOOTH_FEATURE
 

--- a/esp3d/src/core/esp3d.cpp
+++ b/esp3d/src/core/esp3d.cpp
@@ -117,10 +117,12 @@ bool Esp3D::begin()
 #endif //DISPLAY_DEVICE
     //Setup Network
 #if defined(WIFI_FEATURE) || defined(ETH_FEATURE)
+#if !defined(INHIBIT_NETCONFIG_ONBOOT)
     if (!NetConfig::begin()) {
         log_esp3d("Error setup network");
         res = false;
     }
+#endif //INHIBIT_NETCONFIG_ONBOOT
 #endif //WIFI_FEATURE
 #if defined(ESP_AUTOSTART_SCRIPT)
     esp3d_gcode_host.processscript(ESP_AUTOSTART_SCRIPT);


### PR DESCRIPTION
Provide an option, to not automatically start ESP3D's networking
(usually WiFi) on boot.

Which can be turned on, ondemand by issueing [ESP115] from Marlin.

This is different from DEFAULT_ESP_RADIO_MODE as it leaves the
previously configured mode untouched.