### PR TITLE
Add delay before starting camera

### DIFF
--- a/esp3d/src/modules/camera/camera.cpp
+++ b/esp3d/src/modules/camera/camera.cpp
@@ -274,6 +274,7 @@ bool Camera::initHardware()
     gpio_config(&gpio_pwr_config);
     gpio_set_level(GPIO_NUM_32,0);
 #endif //CAMERA_DEVICE == CAMERA_MODEL_AI_THINKER 
+    delay(500);
     log_esp3d("Init camera config");
     esp_err_t err = esp_camera_init(&config);
     if (err != ESP_OK) {


### PR DESCRIPTION
On the ESP32Cam board, when you try to start the camera right after boot-up,
it will give an error, like this:
[E][sccb.c:115] SCCB_Write(): SCCB_Write Failed addr:0x30, reg:0xc7, data:0x10, ret:-1
And then it will fail to init.
They say it is related to poor power supply.

But after I added this 500ms delay, the issue gone.
I suppose it's because after the board boot-up, there is a bunch of things initializing
and comsuming power, which causes camera voltage to be unstable.
And if we wait a bit then those initializations are over
and voltage is more stable.