### PR TITLE
Support for image capture on ESP32-CAM modules

### DIFF
--- a/esp3d/config.h
+++ b/esp3d/config.h
@@ -41,6 +41,9 @@
 
 //FEATURES - comment to disable //////////////////////////////////////////////////////////
 
+// Support for camera bundled with ESP32-CAM modules
+#define ESP32CAMERA
+
 //WEB_UPDATE_FEATURE: allow to flash fw using web UI
 #define WEB_UPDATE_FEATURE
 
@@ -234,19 +237,23 @@ extern const char * pathToFileName(const char * path);
 #include <FS.h>
 #define DEBUG_PIPE NO_PIPE
 #define LOG(string) { FS_FILE logfile = SPIFFS.open("/log.txt", "a+");logfile.print(string);logfile.close();}
+#define LOGF(...) { FS_FILE logfile = SPIFFS.open("/log.txt", "a+");logfile.printf(__VA_ARGS__);logfile.close();}
 #endif
 
 #ifdef DEBUG_OUTPUT_SERIAL
 #define DEBUG_PIPE SERIAL_PIPE
 #define LOG(string) {Serial.print(string);}
+#define LOGF(...) {Serial.printf(__VA_ARGS__);}
 #endif
 #ifdef DEBUG_OUTPUT_TCP
 #include "espcom.h"
 #define LOG(string) {ESPCOM::send2TCP(string, false);}
+#define LOGF(...) {ESPCOM::printf2TCP(false, __VA_ARGS__);}
 #define DEBUG_PIPE TCP_PIPE
 #endif
 #else
 #define LOG(string) {}
+#define LOGF(...) {}
 #define DEBUG_PIPE NO_PIPE
 #endif
 

--- a/esp3d/data/camera.html
+++ b/esp3d/data/camera.html
@@ -1,0 +1,718 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width,initial-scale=1">
+        <title>ESP32 Wi-Fi camera</title>
+        <style>
+            body {
+                font-family: Arial,Helvetica,sans-serif;
+                background: #181818;
+                color: #EFEFEF;
+                font-size: 16px
+            }
+
+            h2 {
+                font-size: 18px
+            }
+
+            section.main {
+                display: flex
+            }
+
+            #menu,section.main {
+                flex-direction: column
+            }
+
+            #menu {
+                display: none;
+                flex-wrap: nowrap;
+                min-width: 340px;
+                background: #363636;
+                padding: 8px;
+                border-radius: 4px;
+                margin-top: -10px;
+                margin-right: 10px;
+            }
+
+            #content {
+                display: flex;
+                flex-wrap: wrap;
+                align-items: stretch
+            }
+
+            figure {
+                padding: 0px;
+                margin: 0;
+                -webkit-margin-before: 0;
+                margin-block-start: 0;
+                -webkit-margin-after: 0;
+                margin-block-end: 0;
+                -webkit-margin-start: 0;
+                margin-inline-start: 0;
+                -webkit-margin-end: 0;
+                margin-inline-end: 0
+            }
+
+            figure img {
+                display: block;
+                width: 100%;
+                height: auto;
+                border-radius: 4px;
+                margin-top: 8px;
+            }
+
+            @media (min-width: 800px) and (orientation:landscape) {
+                #content {
+                    display:flex;
+                    flex-wrap: nowrap;
+                    align-items: stretch
+                }
+
+                figure img {
+                    display: block;
+                    max-width: 100%;
+                    max-height: calc(100vh - 40px);
+                    width: auto;
+                    height: auto
+                }
+
+                figure {
+                    padding: 0 0 0 0px;
+                    margin: 0;
+                    -webkit-margin-before: 0;
+                    margin-block-start: 0;
+                    -webkit-margin-after: 0;
+                    margin-block-end: 0;
+                    -webkit-margin-start: 0;
+                    margin-inline-start: 0;
+                    -webkit-margin-end: 0;
+                    margin-inline-end: 0
+                }
+            }
+
+            section#buttons {
+                display: flex;
+                flex-wrap: nowrap;
+                justify-content: space-between
+            }
+
+            #nav-toggle {
+                cursor: pointer;
+                display: block
+            }
+
+            #nav-toggle-cb {
+                outline: 0;
+                opacity: 0;
+                width: 0;
+                height: 0
+            }
+
+            #nav-toggle-cb:checked+#menu {
+                display: flex
+            }
+
+            .input-group {
+                display: flex;
+                flex-wrap: nowrap;
+                line-height: 22px;
+                margin: 5px 0
+            }
+
+            .input-group>label {
+                display: inline-block;
+                padding-right: 10px;
+                min-width: 47%
+            }
+
+            .input-group input,.input-group select {
+                flex-grow: 1
+            }
+
+            .range-max,.range-min {
+                display: inline-block;
+                padding: 0 5px
+            }
+
+            button {
+                display: block;
+                margin: 5px;
+                padding: 0 12px;
+                border: 0;
+                line-height: 28px;
+                cursor: pointer;
+                color: #fff;
+                background: #ff3034;
+                border-radius: 5px;
+                font-size: 16px;
+                outline: 0
+            }
+
+            button:hover {
+                background: #ff494d
+            }
+
+            button:active {
+                background: #f21c21
+            }
+
+            button.disabled {
+                cursor: default;
+                background: #a0a0a0
+            }
+
+            input[type=range] {
+                -webkit-appearance: none;
+                width: 100%;
+                height: 22px;
+                background: #363636;
+                cursor: pointer;
+                margin: 0
+            }
+
+            input[type=range]:focus {
+                outline: 0
+            }
+
+            input[type=range]::-webkit-slider-runnable-track {
+                width: 100%;
+                height: 2px;
+                cursor: pointer;
+                background: #EFEFEF;
+                border-radius: 0;
+                border: 0 solid #EFEFEF
+            }
+
+            input[type=range]::-webkit-slider-thumb {
+                border: 1px solid rgba(0,0,30,0);
+                height: 22px;
+                width: 22px;
+                border-radius: 50px;
+                background: #ff3034;
+                cursor: pointer;
+                -webkit-appearance: none;
+                margin-top: -11.5px
+            }
+
+            input[type=range]:focus::-webkit-slider-runnable-track {
+                background: #EFEFEF
+            }
+
+            input[type=range]::-moz-range-track {
+                width: 100%;
+                height: 2px;
+                cursor: pointer;
+                background: #EFEFEF;
+                border-radius: 0;
+                border: 0 solid #EFEFEF
+            }
+
+            input[type=range]::-moz-range-thumb {
+                border: 1px solid rgba(0,0,30,0);
+                height: 22px;
+                width: 22px;
+                border-radius: 50px;
+                background: #ff3034;
+                cursor: pointer
+            }
+
+            input[type=range]::-ms-track {
+                width: 100%;
+                height: 2px;
+                cursor: pointer;
+                background: 0 0;
+                border-color: transparent;
+                color: transparent
+            }
+
+            input[type=range]::-ms-fill-lower {
+                background: #EFEFEF;
+                border: 0 solid #EFEFEF;
+                border-radius: 0
+            }
+
+            input[type=range]::-ms-fill-upper {
+                background: #EFEFEF;
+                border: 0 solid #EFEFEF;
+                border-radius: 0
+            }
+
+            input[type=range]::-ms-thumb {
+                border: 1px solid rgba(0,0,30,0);
+                height: 22px;
+                width: 22px;
+                border-radius: 50px;
+                background: #ff3034;
+                cursor: pointer;
+                height: 2px
+            }
+
+            input[type=range]:focus::-ms-fill-lower {
+                background: #EFEFEF
+            }
+
+            input[type=range]:focus::-ms-fill-upper {
+                background: #363636
+            }
+
+            .switch {
+                display: block;
+                position: relative;
+                line-height: 22px;
+                font-size: 16px;
+                height: 22px
+            }
+
+            .switch input {
+                outline: 0;
+                opacity: 0;
+                width: 0;
+                height: 0
+            }
+
+            .slider {
+                width: 50px;
+                height: 22px;
+                border-radius: 22px;
+                cursor: pointer;
+                background-color: grey
+            }
+
+            .slider,.slider:before {
+                display: inline-block;
+                transition: .4s
+            }
+
+            .slider:before {
+                position: relative;
+                content: "";
+                border-radius: 50%;
+                height: 16px;
+                width: 16px;
+                left: 4px;
+                top: 3px;
+                background-color: #fff
+            }
+
+            input:checked+.slider {
+                background-color: #ff3034
+            }
+
+            input:checked+.slider:before {
+                -webkit-transform: translateX(26px);
+                transform: translateX(26px)
+            }
+
+            select {
+                border: 1px solid #363636;
+                font-size: 14px;
+                height: 22px;
+                outline: 0;
+                border-radius: 5px
+            }
+
+            .image-container {
+                position: relative;
+                min-width: 160px
+            }
+
+            .close {
+                position: absolute;
+                right: 5px;
+                top: 5px;
+                background: #ff3034;
+                width: 16px;
+                height: 16px;
+                border-radius: 100px;
+                color: #fff;
+                text-align: center;
+                line-height: 18px;
+                cursor: pointer
+            }
+
+            .hidden {
+                display: none
+            }
+        </style>
+    </head>
+    <body>
+        <section class="main">
+            <div id="logo">
+                <label for="nav-toggle-cb" id="nav-toggle">&#9776;&nbsp;&nbsp;Change camera settings</label>
+            </div>
+            <div id="content">
+                <div id="sidebar">
+                    <input type="checkbox" id="nav-toggle-cb" checked="checked">
+                    <nav id="menu">
+                        <div class="input-group" id="framesize-group">
+                            <label for="framesize">Resolution</label>
+                            <select id="framesize" class="default-action">
+                                <option value="10">UXGA(1600x1200)</option>
+                                <option value="9">SXGA(1280x1024)</option>
+                                <option value="8">XGA(1024x768)</option>
+                                <option value="7">SVGA(800x600)</option>
+                                <option value="6">VGA(640x480)</option>
+                                <option value="5" selected="selected">CIF(400x296)</option>
+                                <option value="4">QVGA(320x240)</option>
+                                <option value="3">HQVGA(240x176)</option>
+                                <option value="0">QQVGA(160x120)</option>
+                            </select>
+                        </div>
+                        <div class="input-group" id="quality-group">
+                            <label for="quality">Quality</label>
+                            <div class="range-min">10</div>
+                            <input type="range" id="quality" min="10" max="63" value="10" class="default-action">
+                            <div class="range-max">63</div>
+                        </div>
+                        <div class="input-group" id="brightness-group">
+                            <label for="brightness">Brightness</label>
+                            <div class="range-min">-2</div>
+                            <input type="range" id="brightness" min="-2" max="2" value="0" class="default-action">
+                            <div class="range-max">2</div>
+                        </div>
+                        <div class="input-group" id="contrast-group">
+                            <label for="contrast">Contrast</label>
+                            <div class="range-min">-2</div>
+                            <input type="range" id="contrast" min="-2" max="2" value="0" class="default-action">
+                            <div class="range-max">2</div>
+                        </div>
+                        <div class="input-group" id="saturation-group">
+                            <label for="saturation">Saturation</label>
+                            <div class="range-min">-2</div>
+                            <input type="range" id="saturation" min="-2" max="2" value="0" class="default-action">
+                            <div class="range-max">2</div>
+                        </div>
+                        <div class="input-group" id="awb-group">
+                            <label for="awb">AWB</label>
+                            <div class="switch">
+                                <input id="awb" type="checkbox" class="default-action" checked="checked">
+                                <label class="slider" for="awb"></label>
+                            </div>
+                        </div>
+                        <div class="input-group" id="awb_gain-group">
+                            <label for="awb_gain">AWB Gain</label>
+                            <div class="switch">
+                                <input id="awb_gain" type="checkbox" class="default-action" checked="checked">
+                                <label class="slider" for="awb_gain"></label>
+                            </div>
+                        </div>
+                        <div class="input-group" id="wb_mode-group">
+                            <label for="wb_mode">WB Mode</label>
+                            <select id="wb_mode" class="default-action">
+                                <option value="0" selected="selected">Auto</option>
+                                <option value="1">Sunny</option>
+                                <option value="2">Cloudy</option>
+                                <option value="3">Office</option>
+                                <option value="4">Home</option>
+                            </select>
+                        </div>
+                        <div class="input-group" id="aec-group">
+                            <label for="aec">AEC SENSOR</label>
+                            <div class="switch">
+                                <input id="aec" type="checkbox" class="default-action" checked="checked">
+                                <label class="slider" for="aec"></label>
+                            </div>
+                        </div>
+                        <div class="input-group" id="aec2-group">
+                            <label for="aec2">AEC DSP</label>
+                            <div class="switch">
+                                <input id="aec2" type="checkbox" class="default-action" checked="checked">
+                                <label class="slider" for="aec2"></label>
+                            </div>
+                        </div>
+                        <div class="input-group" id="ae_level-group">
+                            <label for="ae_level">AE Level</label>
+                            <div class="range-min">-2</div>
+                            <input type="range" id="ae_level" min="-2" max="2" value="0" class="default-action">
+                            <div class="range-max">2</div>
+                        </div>
+                        <div class="input-group" id="aec_value-group">
+                            <label for="aec_value">Exposure</label>
+                            <div class="range-min">0</div>
+                            <input type="range" id="aec_value" min="0" max="1200" value="204" class="default-action">
+                            <div class="range-max">1200</div>
+                        </div>
+                        <div class="input-group" id="agc-group">
+                            <label for="agc">AGC</label>
+                            <div class="switch">
+                                <input id="agc" type="checkbox" class="default-action" checked="checked">
+                                <label class="slider" for="agc"></label>
+                            </div>
+                        </div>
+                        <div class="input-group hidden" id="agc_gain-group">
+                            <label for="agc_gain">Gain</label>
+                            <div class="range-min">1x</div>
+                            <input type="range" id="agc_gain" min="0" max="30" value="5" class="default-action">
+                            <div class="range-max">31x</div>
+                        </div>
+                        <div class="input-group" id="gainceiling-group">
+                            <label for="gainceiling">Gain Ceiling</label>
+                            <div class="range-min">2x</div>
+                            <input type="range" id="gainceiling" min="0" max="6" value="0" class="default-action">
+                            <div class="range-max">128x</div>
+                        </div>
+                        <div class="input-group" id="bpc-group">
+                            <label for="bpc">BPC</label>
+                            <div class="switch">
+                                <input id="bpc" type="checkbox" class="default-action">
+                                <label class="slider" for="bpc"></label>
+                            </div>
+                        </div>
+                        <div class="input-group" id="wpc-group">
+                            <label for="wpc">WPC</label>
+                            <div class="switch">
+                                <input id="wpc" type="checkbox" class="default-action" checked="checked">
+                                <label class="slider" for="wpc"></label>
+                            </div>
+                        </div>
+                        <div class="input-group" id="raw_gma-group">
+                            <label for="raw_gma">Raw GMA</label>
+                            <div class="switch">
+                                <input id="raw_gma" type="checkbox" class="default-action" checked="checked">
+                                <label class="slider" for="raw_gma"></label>
+                            </div>
+                        </div>
+                        <div class="input-group" id="lenc-group">
+                            <label for="lenc">Lens Correction</label>
+                            <div class="switch">
+                                <input id="lenc" type="checkbox" class="default-action" checked="checked">
+                                <label class="slider" for="lenc"></label>
+                            </div>
+                        </div>
+                        <div class="input-group" id="hmirror-group">
+                            <label for="hmirror">H-Mirror</label>
+                            <div class="switch">
+                                <input id="hmirror" type="checkbox" class="default-action" checked="checked">
+                                <label class="slider" for="hmirror"></label>
+                            </div>
+                        </div>
+                        <div class="input-group" id="vflip-group">
+                            <label for="vflip">V-Flip</label>
+                            <div class="switch">
+                                <input id="vflip" type="checkbox" class="default-action" checked="checked">
+                                <label class="slider" for="vflip"></label>
+                            </div>
+                        </div>
+                        <div class="input-group" id="dcw-group">
+                            <label for="dcw">DCW (Downsize EN)</label>
+                            <div class="switch">
+                                <input id="dcw" type="checkbox" class="default-action" checked="checked">
+                                <label class="slider" for="dcw"></label>
+                            </div>
+                        </div>
+                        <div class="input-group" id="flash-group">
+                            <label for="flash">LED flash</label>
+                            <div class="switch">
+                                <input id="flash" type="checkbox" class="default-action">
+                                <label class="slider" for="flash"></label>
+                            </div>
+                        </div>
+                        <section id="buttons">
+                            <button id="get-still">Get Still</button>
+                            <button id="toggle-stream">Start Stream</button>
+                        </section>
+                    </nav>
+                </div>
+                <figure>
+                    <div id="stream-container" class="image-container hidden">
+                        <div class="close" id="close-stream">×</div>
+                        <img id="stream" src="">
+                    </div>
+                </figure>
+            </div>
+        </section>
+        <script>
+document.addEventListener('DOMContentLoaded', function (event) {
+  var baseHost = document.location.origin
+  var streamHost = baseHost + ":7000"
+
+  const hide = el => {
+    el.classList.add('hidden')
+  }
+  const show = el => {
+    el.classList.remove('hidden')
+  }
+
+  const disable = el => {
+    el.classList.add('disabled')
+    el.disabled = true
+  }
+
+  const enable = el => {
+    el.classList.remove('disabled')
+    el.disabled = false
+  }
+
+  const updateValue = (el, value, updateRemote) => {
+    updateRemote = updateRemote == null ? true : updateRemote
+    let initialValue
+    if (el.type === 'checkbox') {
+      initialValue = el.checked
+      value = !!value
+      el.checked = value
+    } else {
+      initialValue = el.value
+      el.value = value
+    }
+
+    if (updateRemote && initialValue !== value) {
+      updateConfig(el);
+    } else if(!updateRemote){
+      if(el.id === "aec"){
+        value ? hide(exposure) : show(exposure)
+      } else if(el.id === "agc"){
+        if (value) {
+          show(gainCeiling)
+          hide(agcGain)
+        } else {
+          hide(gainCeiling)
+          show(agcGain)
+        }
+      } else if(el.id === "awb_gain"){
+        value ? show(wb) : hide(wb)
+      } else if(el.id === "face_recognize"){
+        value ? enable(enrollButton) : disable(enrollButton)
+      }
+    }
+  }
+
+  function updateConfig (el) {
+    let value
+    switch (el.type) {
+      case 'checkbox':
+        value = el.checked ? 1 : 0
+        break
+      case 'range':
+      case 'select-one':
+        value = el.value
+        break
+      case 'button':
+      case 'submit':
+        value = '1'
+        break
+      default:
+        return
+    }
+
+    const query = `${baseHost}/cam_status?var=${el.id}&val=${value}`
+
+    fetch(query)
+      .then(response => {
+        console.log(`request to ${query} finished, status: ${response.status}`)
+      })
+  }
+
+  document
+    .querySelectorAll('.close')
+    .forEach(el => {
+      el.onclick = () => {
+        hide(el.parentNode)
+      }
+    })
+
+  // read initial values
+  fetch(`${baseHost}/cam_status`)
+    .then(function (response) {
+      return response.json()
+    })
+    .then(function (state) {
+      document
+        .querySelectorAll('.default-action')
+        .forEach(el => {
+          updateValue(el, state[el.id], false)
+        })
+    })
+
+  const view = document.getElementById('stream')
+  const viewContainer = document.getElementById('stream-container')
+  const stillButton = document.getElementById('get-still')
+  const streamButton = document.getElementById('toggle-stream')
+  const closeButton = document.getElementById('close-stream')
+
+  const stopStream = () => {
+    window.stop();
+    streamButton.innerHTML = 'Start Stream'
+  }
+
+  const startStream = () => {
+    view.src = `${streamHost}/stream`
+    show(viewContainer)
+    streamButton.innerHTML = 'Stop Stream'
+  }
+
+  // Attach actions to buttons
+  stillButton.onclick = () => {
+    stopStream()
+    view.src = `${streamHost}/capture?_cb=${Date.now()}`
+    show(viewContainer)
+  }
+
+  closeButton.onclick = () => {
+    stopStream()
+    hide(viewContainer)
+  }
+
+  streamButton.onclick = () => {
+    const streamEnabled = streamButton.innerHTML === 'Stop Stream'
+    if (streamEnabled) {
+      stopStream()
+    } else {
+      startStream()
+    }
+  }
+
+  enrollButton.onclick = () => {
+    updateConfig(enrollButton)
+  }
+
+  // Attach default on change action
+  document
+    .querySelectorAll('.default-action')
+    .forEach(el => {
+      el.onchange = () => updateConfig(el)
+    })
+
+  // Custom actions
+  // Gain
+  const agc = document.getElementById('agc')
+  const agcGain = document.getElementById('agc_gain-group')
+  const gainCeiling = document.getElementById('gainceiling-group')
+  agc.onchange = () => {
+    updateConfig(agc)
+    if (agc.checked) {
+      show(gainCeiling)
+      hide(agcGain)
+    } else {
+      hide(gainCeiling)
+      show(agcGain)
+    }
+  }
+
+  // Exposure
+  const aec = document.getElementById('aec')
+  const exposure = document.getElementById('aec_value-group')
+  aec.onchange = () => {
+    updateConfig(aec)
+    aec.checked ? hide(exposure) : show(exposure)
+  }
+
+  // AWB
+  const awb = document.getElementById('awb_gain')
+  const wb = document.getElementById('wb_mode-group')
+  awb.onchange = () => {
+    updateConfig(awb)
+    awb.checked ? show(wb) : hide(wb)
+  }
+
+  // Framesize
+  const framesize = document.getElementById('framesize')
+
+  framesize.onchange = () => {
+    updateConfig(framesize)
+  }
+})
+
+        </script>
+    </body>
+</html>

--- a/esp3d/esp32camera.h
+++ b/esp3d/esp32camera.h
@@ -1,0 +1,31 @@
+#pragma once
+#include "Arduino.h"
+
+#define PWDN_GPIO_NUM     32
+#define RESET_GPIO_NUM    -1
+#define XCLK_GPIO_NUM      0
+#define SIOD_GPIO_NUM     26
+#define SIOC_GPIO_NUM     27
+
+#define Y9_GPIO_NUM       35
+#define Y8_GPIO_NUM       34
+#define Y7_GPIO_NUM       39
+#define Y6_GPIO_NUM       36
+#define Y5_GPIO_NUM       21
+#define Y4_GPIO_NUM       19
+#define Y3_GPIO_NUM       18
+#define Y2_GPIO_NUM        5
+#define VSYNC_GPIO_NUM    25
+#define HREF_GPIO_NUM     23
+#define PCLK_GPIO_NUM     22
+
+#define LED_GPIO_NUM       4
+// Set to 1 if you want the camera rotated 180 degrees by default, 0 otherwise
+#define ROTATE_CAMERA_180  1
+
+// Image streaming is running on a separate web server from the one for camera status and the rest of ESP3D.
+// Both servers can only handle one connection at a time
+bool cameraInit(void);
+void startCameraFrameServer();
+String getCameraStatusJSON(void);
+int setCameraStatus(String variable, String value);

--- a/esp3d/esp32camera_stream.cpp
+++ b/esp3d/esp32camera_stream.cpp
@@ -1,0 +1,240 @@
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "Arduino.h"
+
+#ifdef ARDUINO_ARCH_ESP32
+#include "esp_timer.h"
+#include "esp_camera.h"
+#include "img_converters.h"
+#include "esp_http_server.h" // We use the ESP-IDF HTTP server for streaming pictures and the Arduino web server for everything else
+
+#include "fb_gfx.h"
+#include "fd_forward.h"
+#include "fr_forward.h"
+
+#include "config.h"
+#include "esp32camera.h"
+
+typedef struct {
+    httpd_req_t *req;
+    size_t len;
+} jpg_chunking_t;
+
+#define PART_BOUNDARY "123456789000000000000987654321"
+static const char* _STREAM_CONTENT_TYPE = "multipart/x-mixed-replace;boundary=" PART_BOUNDARY;
+static const char* _STREAM_BOUNDARY = "\r\n--" PART_BOUNDARY "\r\n";
+static const char* _STREAM_PART = "Content-Type: image/jpeg\r\nContent-Length: %u\r\n\r\n";
+
+static httpd_handle_t stream_httpd = NULL;
+
+static size_t jpg_encode_stream(void * arg, size_t index, const void* data, size_t len)
+{
+    jpg_chunking_t *j = (jpg_chunking_t *)arg;
+    if (!index){
+        j->len = 0;
+    }
+
+    if (httpd_resp_send_chunk(j->req, (const char *)data, len) != ESP_OK){
+        return 0;
+    }
+
+    j->len += len;
+    return len;
+}
+
+static esp_err_t capture_handler(httpd_req_t *req)
+{
+    camera_fb_t * fb = NULL;
+    esp_err_t res = ESP_OK;
+
+    fb = esp_camera_fb_get();
+    if (!fb) {
+        LOG("Camera capture failed\n");
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+
+    httpd_resp_set_type(req, "image/jpeg");
+    httpd_resp_set_hdr(req, "Content-Disposition", "inline; filename=capture.jpg");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+
+    size_t out_len, out_width, out_height;
+    uint8_t * out_buf;
+    bool s;
+    if (fb->width > 400) {
+        if (fb->format == PIXFORMAT_JPEG) {
+            res = httpd_resp_send(req, (const char *)fb->buf, fb->len);
+        } else {
+            jpg_chunking_t jchunk = {req, 0};
+            res = frame2jpg_cb(fb, 80, jpg_encode_stream, &jchunk) ? ESP_OK : ESP_FAIL;
+            httpd_resp_send_chunk(req, NULL, 0);
+        }
+
+        esp_camera_fb_return(fb);
+        return res;
+    } else {
+        dl_matrix3du_t *image_matrix = dl_matrix3du_alloc(1, fb->width, fb->height, 3);
+        if (!image_matrix) {
+            esp_camera_fb_return(fb);
+            LOG("dl_matrix3du_alloc failed\n");
+            httpd_resp_send_500(req);
+            return ESP_FAIL;
+        }
+
+        out_buf = image_matrix->item;
+        out_len = fb->width * fb->height * 3;
+        out_width = fb->width;
+        out_height = fb->height;
+
+        s = fmt2rgb888(fb->buf, fb->len, fb->format, out_buf);
+        esp_camera_fb_return(fb);
+        if (!s) {
+            dl_matrix3du_free(image_matrix);
+            LOG("to rgb888 failed\n");
+            httpd_resp_send_500(req);
+            return ESP_FAIL;
+        }
+
+        jpg_chunking_t jchunk = {req, 0};
+        s = fmt2jpg_cb(out_buf, out_len, out_width, out_height, PIXFORMAT_RGB888, 90, jpg_encode_stream, &jchunk);
+        dl_matrix3du_free(image_matrix);
+        if (!s) {
+            LOG("JPEG compression failed\n");
+            return ESP_FAIL;
+        }
+
+        return res;
+    }
+}
+
+static esp_err_t stream_handler(httpd_req_t *req)
+{
+    camera_fb_t * fb = NULL;
+    esp_err_t res = ESP_OK;
+    size_t _jpg_buf_len = 0;
+    uint8_t * _jpg_buf = NULL;
+    char * part_buf[64];
+    dl_matrix3du_t *image_matrix = NULL;
+
+    res = httpd_resp_set_type(req, _STREAM_CONTENT_TYPE);
+    if (res != ESP_OK){
+        return res;
+    }
+
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+
+    while (true) {
+        fb = esp_camera_fb_get();
+        if (!fb) {
+            LOG("Camera capture failed\n");
+            res = ESP_FAIL;
+        } else {
+            if (fb->width > 400){
+                if (fb->format != PIXFORMAT_JPEG){
+                    bool jpeg_converted = frame2jpg(fb, 80, &_jpg_buf, &_jpg_buf_len);
+                    esp_camera_fb_return(fb);
+                    fb = NULL;
+                    if (!jpeg_converted){
+                        LOG("JPEG compression failed\n");
+                        res = ESP_FAIL;
+                    }
+                } else {
+                    _jpg_buf_len = fb->len;
+                    _jpg_buf = fb->buf;
+                }
+            } else {
+                image_matrix = dl_matrix3du_alloc(1, fb->width, fb->height, 3);
+                if (!image_matrix) {
+                    LOG("dl_matrix3du_alloc failed\n");
+                    res = ESP_FAIL;
+                } else {
+                    if (!fmt2rgb888(fb->buf, fb->len, fb->format, image_matrix->item)){
+                        LOG("fmt2rgb888 failed\n");
+                        res = ESP_FAIL;
+                    } else {
+                        if (fb->format != PIXFORMAT_JPEG){
+                            if (!fmt2jpg(image_matrix->item, fb->width*fb->height*3, fb->width, fb->height, PIXFORMAT_RGB888, 90, &_jpg_buf, &_jpg_buf_len)){
+                                LOG("fmt2jpg failed\n");
+                                res = ESP_FAIL;
+                            }
+                            esp_camera_fb_return(fb);
+                            fb = NULL;
+                        } else {
+                            _jpg_buf = fb->buf;
+                            _jpg_buf_len = fb->len;
+                        }
+                    }
+
+                    dl_matrix3du_free(image_matrix);
+                }
+            }
+        }
+
+        if (res == ESP_OK){
+            size_t hlen = snprintf((char *)part_buf, 64, _STREAM_PART, _jpg_buf_len);
+            res = httpd_resp_send_chunk(req, (const char *)part_buf, hlen);
+        }
+
+        if (res == ESP_OK){
+            res = httpd_resp_send_chunk(req, (const char *)_jpg_buf, _jpg_buf_len);
+        }
+
+        if (res == ESP_OK){
+            res = httpd_resp_send_chunk(req, _STREAM_BOUNDARY, strlen(_STREAM_BOUNDARY));
+        }
+
+        if (fb){
+            esp_camera_fb_return(fb);
+            fb = NULL;
+            _jpg_buf = NULL;
+        } else if (_jpg_buf){
+            free(_jpg_buf);
+            _jpg_buf = NULL;
+        }
+
+        if (res != ESP_OK){
+            break;
+        }
+    }
+
+    return res;
+}
+
+void startCameraFrameServer()
+{
+    httpd_config_t config = HTTPD_DEFAULT_CONFIG();
+
+    httpd_uri_t capture_uri = {
+        .uri       = "/capture",
+        .method    = HTTP_GET,
+        .handler   = capture_handler,
+        .user_ctx  = NULL
+    };
+
+   httpd_uri_t stream_uri = {
+        .uri       = "/stream",
+        .method    = HTTP_GET,
+        .handler   = stream_handler,
+        .user_ctx  = NULL
+    };
+
+    config.server_port = 7000;
+    config.ctrl_port = 7001;
+    LOGF("Starting stream server on port: '%d'\n", config.server_port);
+    if (httpd_start(&stream_httpd, &config) == ESP_OK) {
+        httpd_register_uri_handler(stream_httpd, &stream_uri);
+        httpd_register_uri_handler(stream_httpd, &capture_uri);
+    }
+}
+#endif // ARDUINO_ARCH_ESP32

--- a/esp3d/esp32camera_webcfg.cpp
+++ b/esp3d/esp32camera_webcfg.cpp
@@ -1,0 +1,229 @@
+#include "Arduino.h"
+
+#ifdef ARDUINO_ARCH_ESP32
+#include "esp_timer.h"
+#include "esp_camera.h"
+#include "img_converters.h"
+
+#include "fb_gfx.h"
+#include "fd_forward.h"
+#include "fr_forward.h"
+
+#include "config.h"
+#include "esp32camera.h"
+
+enum CAMERA_PARAM_ENUM {
+    CAMERA_PARAM_FRAMESIZE,
+    CAMERA_PARAM_QUALITY,
+    CAMERA_PARAM_CONTRAST,
+    CAMERA_PARAM_BRIGHTNESS,
+    CAMERA_PARAM_SATURATION,
+    CAMERA_PARAM_GAINCEILING,
+    CAMERA_PARAM_FLASH,
+    CAMERA_PARAM_AWB,
+    CAMERA_PARAM_AGC,
+    CAMERA_PARAM_AEC,
+    CAMERA_PARAM_HMIRROR,
+    CAMERA_PARAM_VFLIP,
+    CAMERA_PARAM_AWB_GAIN,
+    CAMERA_PARAM_AGC_GAIN,
+    CAMERA_PARAM_AEC_VALUE,
+    CAMERA_PARAM_AEC2,
+    CAMERA_PARAM_DCW,
+    CAMERA_PARAM_BPC,
+    CAMERA_PARAM_WPC,
+    CAMERA_PARAM_RAW_GMA,
+    CAMERA_PARAM_LENC,
+    CAMERA_PARAM_SPECIAL_EFFECT,
+    CAMERA_PARAM_WB_MODE,
+    CAMERA_PARAM_AE_LEVEL,
+    CAMERA_PARAM_SHARPNESS,
+    CAMERA_PARAMS_COUNT
+};
+
+static const char* const camera_param_strings[25] = {
+    "framesize",
+    "quality",
+    "contrast",
+    "brightness",
+    "saturation",
+    "gainceiling",
+    "flash",
+    "awb",
+    "agc",
+    "aec",
+    "hmirror",
+    "vflip",
+    "awb_gain",
+    "agc_gain",
+    "aec_value",
+    "aec2",
+    "dcw",
+    "bpc",
+    "wpc",
+    "raw_gma",
+    "lenc",
+    "special_effect",
+    "wb_mode",
+    "ae_level",
+    "sharpness",
+};
+
+#define PARAM_STR(x) camera_param_strings[CAMERA_PARAM_ ## x]
+
+static const char* json_param_int_fmt = "\"%s\":%d%c";
+
+String getCameraStatusJSON(void)
+{
+    sensor_t * s = esp_camera_sensor_get();
+    String resp = "{";
+
+    #define PRINT_JSON_PARAM_INT(str, param, value, last) do { \
+        char print_buf[32]; \
+        snprintf(print_buf, 32, json_param_int_fmt, PARAM_STR(param), value, last ? ' ': ','); \
+        str +=  print_buf; \
+    } while (0)
+
+    PRINT_JSON_PARAM_INT(resp, FRAMESIZE, s->status.framesize, false);
+    PRINT_JSON_PARAM_INT(resp, QUALITY, s->status.quality, false);
+    PRINT_JSON_PARAM_INT(resp, BRIGHTNESS, s->status.brightness, false);
+    PRINT_JSON_PARAM_INT(resp, CONTRAST, s->status.contrast, false);
+    PRINT_JSON_PARAM_INT(resp, SATURATION, s->status.saturation, false);
+    PRINT_JSON_PARAM_INT(resp, SHARPNESS, s->status.sharpness, false);
+    PRINT_JSON_PARAM_INT(resp, SPECIAL_EFFECT, s->status.special_effect, false);
+    PRINT_JSON_PARAM_INT(resp, WB_MODE, s->status.wb_mode, false);
+    PRINT_JSON_PARAM_INT(resp, AWB, s->status.awb, false);
+    PRINT_JSON_PARAM_INT(resp, AWB_GAIN, s->status.awb_gain, false);
+    PRINT_JSON_PARAM_INT(resp, AEC, s->status.aec, false);
+    PRINT_JSON_PARAM_INT(resp, AEC2, s->status.aec2, false);
+    PRINT_JSON_PARAM_INT(resp, AE_LEVEL, s->status.ae_level, false);
+    PRINT_JSON_PARAM_INT(resp, AEC_VALUE, s->status.aec_value, false);
+    PRINT_JSON_PARAM_INT(resp, AGC, s->status.agc, false);
+    PRINT_JSON_PARAM_INT(resp, AGC_GAIN, s->status.agc_gain, false);
+    PRINT_JSON_PARAM_INT(resp, GAINCEILING, s->status.gainceiling, false);
+    PRINT_JSON_PARAM_INT(resp, BPC, s->status.bpc, false);
+    PRINT_JSON_PARAM_INT(resp, WPC, s->status.wpc, false);
+    PRINT_JSON_PARAM_INT(resp, RAW_GMA, s->status.raw_gma, false);
+    PRINT_JSON_PARAM_INT(resp, LENC, s->status.lenc, false);
+    PRINT_JSON_PARAM_INT(resp, VFLIP, s->status.vflip, false);
+    PRINT_JSON_PARAM_INT(resp, HMIRROR, s->status.hmirror, false);
+    PRINT_JSON_PARAM_INT(resp, DCW, s->status.dcw, false);
+    PRINT_JSON_PARAM_INT(resp, FLASH, s->status.colorbar, true);
+    resp += "}";
+    return resp;
+}
+
+int setCameraStatus(String variable, String value)
+{
+    int res;
+    int val = atoi(value.c_str());
+    int param_idx = 0;
+    for (; param_idx < CAMERA_PARAMS_COUNT; param_idx++) {
+        if (variable.equals(camera_param_strings[param_idx])) {
+            break;
+        }
+    }
+
+    sensor_t * s = esp_camera_sensor_get();
+    switch (param_idx) {
+        case CAMERA_PARAM_FRAMESIZE: {
+            if (s->pixformat == PIXFORMAT_JPEG){
+                res = s->set_framesize(s, (framesize_t)val);
+            } else {
+                res = 0;
+            }
+        }
+        break;
+        case CAMERA_PARAM_QUALITY:        res = s->set_quality(s, val); break;
+        case CAMERA_PARAM_CONTRAST:       res = s->set_contrast(s, val); break;
+        case CAMERA_PARAM_BRIGHTNESS:     res = s->set_brightness(s, val); break;
+        case CAMERA_PARAM_SATURATION:     res = s->set_saturation(s, val); break;
+        case CAMERA_PARAM_GAINCEILING:    res = s->set_gainceiling(s, (gainceiling_t)val); break;
+        case CAMERA_PARAM_FLASH:          digitalWrite(LED_GPIO_NUM, val); res = 0; break;
+        case CAMERA_PARAM_AWB:            res = s->set_whitebal(s, val); break;
+        case CAMERA_PARAM_AGC:            res = s->set_gain_ctrl(s, val); break;
+        case CAMERA_PARAM_AEC:            res = s->set_exposure_ctrl(s, val); break;
+        case CAMERA_PARAM_HMIRROR:        res = s->set_hmirror(s, val); break;
+        case CAMERA_PARAM_VFLIP:          res = s->set_vflip(s, val); break;
+        case CAMERA_PARAM_AWB_GAIN:       res = s->set_awb_gain(s, val); break;
+        case CAMERA_PARAM_AGC_GAIN:       res = s->set_agc_gain(s, val); break;
+        case CAMERA_PARAM_AEC_VALUE:      res = s->set_aec_value(s, val); break;
+        case CAMERA_PARAM_AEC2:           res = s->set_aec2(s, val); break;
+        case CAMERA_PARAM_DCW:            res = s->set_dcw(s, val); break;
+        case CAMERA_PARAM_BPC:            res = s->set_bpc(s, val); break;
+        case CAMERA_PARAM_WPC:            res = s->set_wpc(s, val); break;
+        case CAMERA_PARAM_RAW_GMA:        res = s->set_raw_gma(s, val); break;
+        case CAMERA_PARAM_LENC:           res = s->set_lenc(s, val); break;
+        case CAMERA_PARAM_SPECIAL_EFFECT: res = s->set_special_effect(s, val); break;
+        case CAMERA_PARAM_WB_MODE:        res = s->set_wb_mode(s, val); break;
+        case CAMERA_PARAM_AE_LEVEL:       res = s->set_ae_level(s, val); break;
+        case CAMERA_PARAM_SHARPNESS:      res = s->set_sharpness(s, val); break;
+        default: res = -1; break;
+    }
+
+    return res;
+}
+
+bool cameraInit(void)
+{
+    pinMode(LED_GPIO_NUM, OUTPUT);
+
+    camera_config_t config;
+    config.ledc_channel = LEDC_CHANNEL_0;
+    config.ledc_timer = LEDC_TIMER_0;
+    config.pin_d0 = Y2_GPIO_NUM;
+    config.pin_d1 = Y3_GPIO_NUM;
+    config.pin_d2 = Y4_GPIO_NUM;
+    config.pin_d3 = Y5_GPIO_NUM;
+    config.pin_d4 = Y6_GPIO_NUM;
+    config.pin_d5 = Y7_GPIO_NUM;
+    config.pin_d6 = Y8_GPIO_NUM;
+    config.pin_d7 = Y9_GPIO_NUM;
+    config.pin_xclk = XCLK_GPIO_NUM;
+    config.pin_pclk = PCLK_GPIO_NUM;
+    config.pin_vsync = VSYNC_GPIO_NUM;
+    config.pin_href = HREF_GPIO_NUM;
+    config.pin_sscb_sda = SIOD_GPIO_NUM;
+    config.pin_sscb_scl = SIOC_GPIO_NUM;
+    config.pin_pwdn = PWDN_GPIO_NUM;
+    config.pin_reset = RESET_GPIO_NUM;
+    config.xclk_freq_hz = 20000000;
+    config.pixel_format = PIXFORMAT_JPEG;
+
+    //init with high specs to pre-allocate larger buffers
+    if (psramFound()) {
+        LOG("PSRAM found\n");
+        config.frame_size = FRAMESIZE_UXGA;
+        config.jpeg_quality = 10;
+        config.fb_count = 2;
+    } else {
+        LOG("PSRAM not found\n");
+        config.frame_size = FRAMESIZE_SVGA;
+        config.jpeg_quality = 12;
+        config.fb_count = 1;
+    }
+
+    // camera init
+    esp_err_t err = esp_camera_init(&config);
+    if (err != ESP_OK) {
+        LOGF("Camera init failed with error 0x%x", err);
+        return false;
+    }
+
+    sensor_t * s = esp_camera_sensor_get();
+    LOGF("Sensor PID: %d\n", s->id.PID);
+    LOGF("Sensor full ID: %08x\n", *(uint32_t*)(&s->id));
+    // drop down frame size for higher initial frame rate
+    int ret = s->set_framesize(s, FRAMESIZE_VGA);
+#if ROTATE_CAMERA_180
+    // rotate sensor 180 degrees
+    ret |= s->set_hmirror(s, 1);
+    ret |= s->set_vflip(s, 1);
+#endif
+    if (ret != 0) {
+        return false;
+    }
+
+    return true;
+}
+#endif // ARDUINO_ARCH_ESP32

--- a/esp3d/esp3d.cpp
+++ b/esp3d/esp3d.cpp
@@ -88,6 +88,10 @@ DHTesp dht;
 #include "syncwebserver.h"
 #endif
 
+#if defined (ESP32CAMERA)
+#include "esp32camera.h"
+#endif //defined (ESP32CAMERA)
+
 //Contructor
 Esp3D::Esp3D()
 {
@@ -243,6 +247,11 @@ void Esp3D::begin(uint16_t startdelayms, uint16_t recoverydelayms)
 
     	}
     #endif*/
+#ifdef ESP32CAMERA
+    if (cameraInit()) {
+        startCameraFrameServer();
+    }
+#endif
 
 #ifdef ASYNCWEBSERVER
     if (WiFi.getMode() != WIFI_AP) {

--- a/esp3d/espcom.cpp
+++ b/esp3d/espcom.cpp
@@ -385,6 +385,21 @@ void ESPCOM::send2TCP (const char * data, bool async)
         }
     }
 }
+void ESPCOM::printf2TCP(bool async, const char * fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    int size = vsnprintf(NULL, 0, fmt, args);
+    if (size <= 0) {
+        return;
+    }
+
+    size = size > 1024 ? 1024 : size; // Limit temp string size to some reasonable maximum
+    std::unique_ptr<char[]> data(new char[size]);
+    vsnprintf(data.get(), size, fmt, args);
+    va_end(args);
+    send2TCP(data.get(), async);
+}
 #endif
 
 bool ESPCOM::processFromSerial (bool async)

--- a/esp3d/espcom.h
+++ b/esp3d/espcom.h
@@ -48,6 +48,7 @@ public:
     static void send2TCP (const __FlashStringHelper *data, bool async = false);
     static void send2TCP (String data, bool async = false);
     static void send2TCP (const char * data, bool async = false);
+    static void printf2TCP(bool async, const char * fmt, ...);
 #endif
     static bool block_2_printer;
 #ifdef ESP_OLED_FEATURE

--- a/esp3d/syncwebserver.h
+++ b/esp3d/syncwebserver.h
@@ -32,6 +32,7 @@ extern void handle_not_found();
 extern void handle_web_command();
 extern void handle_web_command_silent();
 extern void handle_serial_SDFileList();
+extern void handle_camera_status();
 extern void SDFile_serial_upload();
 extern WebSocketsServer * socket_server;
 extern void webSocketEvent(uint8_t num, WStype_t type, uint8_t * payload, size_t length);

--- a/esp3d/webinterface.cpp
+++ b/esp3d/webinterface.cpp
@@ -357,6 +357,7 @@ WEBINTERFACE_CLASS::WEBINTERFACE_CLASS (int port) : web_server (port)
     web_server.on ("/command_silent", HTTP_ANY, handle_web_command_silent);
     //Serial SD management
     web_server.on ("/upload_serial", HTTP_ANY, handle_serial_SDFileList, SDFile_serial_upload);
+    web_server.on ("/cam_status", HTTP_ANY, handle_camera_status);
 
     blockserial = false;
     restartmodule = false;


### PR DESCRIPTION
I added code to allow ESP32-CAM modules to capture images and send them over the network. One step closer to having the same functionality as Octoprint, but for a fraction of the price ;)

Code is adapted from [Espressif's example web server](https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/Camera/CameraWebServer). Fits in 1227566 bytes of Flash, even though I use a separate web server for streaming images. I also added a new endpoint to the default web server to get and set camera parameters.

The camera.html file is also adapted from the example, it could use some cleanup, optimization and styling to fit with the rest of interface. I'm not good with web development though, so maybe I'll leave it to someone else. 

To allow `/camera.html` to be displayed in the iframe, I modified `index.html` and changed
```t.indexOf("rtp://")&&(e="http://"+e)```
to
```t.indexOf("rtp://")&&(!(t.startsWith("/")))&&(e="http://"+e)```

Below is a screenshot of the new firmware in action:
![Screenshot 2022-07-16 at 23-35-00 EspPrinter](https://user-images.githubusercontent.com/5717684/179372813-a1b4e863-0a29-4f83-aa62-5abcef8a0f39.png)

