### PR TITLE
Fixed building for esp32-c3

### DIFF
--- a/esp3d/src/modules/serial/serial_service.cpp
+++ b/esp3d/src/modules/serial/serial_service.cpp
@@ -34,8 +34,15 @@ HardwareSerial * Serials[MAX_SERIAL] = {&Serial, &Serial1};
 #endif //ARDUINO_ARCH_ESP8266
 
 #if defined (ARDUINO_ARCH_ESP32)
-#define MAX_SERIAL 3
-HardwareSerial * Serials[MAX_SERIAL] = {&Serial, &Serial1, &Serial2};
+
+    #if defined (CONFIG_IDF_TARGET_ESP32C3)
+        #define MAX_SERIAL 2
+        HardwareSerial * Serials[MAX_SERIAL] = {&Serial, &Serial1};
+    #else
+        #define MAX_SERIAL 3
+        HardwareSerial * Serials[MAX_SERIAL] = {&Serial, &Serial1, &Serial2};
+    #endif
+
 #endif //ARDUINO_ARCH_ESP32
 
 


### PR DESCRIPTION
ESP32-C3 only has 2 serial ports.

Signed-off-by: Xstasy <x@gbps.io>