### PR TITLE
(v2) Add Home Assistant notification support

### DIFF
--- a/esp3d/command.cpp
+++ b/esp3d/command.cpp
@@ -1246,6 +1246,8 @@ bool COMMAND::execute_command (int cmd, String cmd_params, tpipe output, level_a
             ESPCOM::print ( (const char *) CONFIG::intTostr (ESP_LINE_NOTIFICATION), output, espresponse);
             ESPCOM::print (F("\"},{\"IFTTT\":\""), output, espresponse);
             ESPCOM::print ( (const char *) CONFIG::intTostr (ESP_IFTTT_NOTIFICATION), output, espresponse);
+            ESPCOM::print (F("\"},{\"POST\":\""), output, espresponse);
+            ESPCOM::print ( (const char *) CONFIG::intTostr (ESP_POST_NOTIFICATION), output, espresponse);
             ESPCOM::print (F("\"}]}"), output, espresponse);
             ESPCOM::println (F (","), output, espresponse);
             //Token 1
@@ -1739,7 +1741,7 @@ bool COMMAND::execute_command (int cmd, String cmd_params, tpipe output, level_a
             }
             char sbuf[MAX_DATA_LENGTH + 1];
             static String tmp;
-            tmp = (Ntype == ESP_PUSHOVER_NOTIFICATION)?"PUSHOVER":(Ntype == ESP_EMAIL_NOTIFICATION)?"EMAIL":(Ntype == ESP_LINE_NOTIFICATION)?"LINE":(Ntype == ESP_IFTTT_NOTIFICATION)?"IFTTT":"NONE";
+            tmp = (Ntype == ESP_PUSHOVER_NOTIFICATION)?"PUSHOVER":(Ntype == ESP_EMAIL_NOTIFICATION)?"EMAIL":(Ntype == ESP_LINE_NOTIFICATION)?"LINE":(Ntype == ESP_IFTTT_NOTIFICATION)?"IFTTT":(Ntype == ESP_POST_NOTIFICATION)?"POST":"NONE";
             if (CONFIG::read_string (ESP_NOTIFICATION_SETTINGS, sbuf, MAX_NOTIFICATION_SETTINGS_LENGTH) ) {
                 tmp+= " ";
                 tmp += sbuf;
@@ -1762,6 +1764,8 @@ bool COMMAND::execute_command (int cmd, String cmd_params, tpipe output, level_a
                     Ntype = ESP_LINE_NOTIFICATION;
                 } else if (parameter == "IFTTT") {
                     Ntype = ESP_IFTTT_NOTIFICATION;
+                } else if (parameter == "POST") {
+                    Ntype = ESP_POST_NOTIFICATION;
                 } else {
                     ESPCOM::println (INCORRECT_CMD_MSG, output, espresponse);
                     return false;

--- a/esp3d/config.h
+++ b/esp3d/config.h
@@ -150,6 +150,17 @@
 //For FW which has issue with checksum or not handling M110 properly///////
 //#define DISABLE_SERIAL_CHECKSUM
 
+/* *** Home Assistant notification ***
+ * Home Assistant tokens are too long to pass via serial.
+ * Create a long-lived access token here: http://homeassistant.local:8123/profile
+ * And replace "YOUR-TOKEN" below.
+ * Usage: In a Marlin custom menu or at the end of your gcode add:
+     M118 [ESP610]type=POST TS=/api/services/switch/toggle#homeassistant.local:8123
+     M118 [ESP600]{"entity_id": "switch.3d_printer_switch"}
+*/
+
+#define HOME_ASSISTANT_TOKEN "Bearer YOUR-TOKEN"
+
 //Do not Edit after this line //////////////////////////////////////////////
 
 //DEBUG Flag do not do this when connected to printer !!!
@@ -421,6 +432,7 @@ const int DEFAULT_DHT_INTERVAL = 30;
 #define ESP_EMAIL_NOTIFICATION      2
 #define ESP_LINE_NOTIFICATION       3
 #define ESP_IFTTT_NOTIFICATION      4
+#define ESP_POST_NOTIFICATION       5
 
 #ifdef SDCARD_FEATURE
 #define DEFAULT_IS_DIRECT_SD 1

--- a/esp3d/config.h
+++ b/esp3d/config.h
@@ -155,8 +155,8 @@
  * Create a long-lived access token here: http://homeassistant.local:8123/profile
  * And replace "YOUR-TOKEN" below.
  * Usage: In a Marlin custom menu or at the end of your gcode add:
-     M118 [ESP610]type=POST TS=/api/services/switch/toggle#homeassistant.local:8123
-     M118 [ESP600]{"entity_id": "switch.3d_printer_switch"}
+     M118 [ESP610] type=POST TS=#homeassistant.local:8123
+     M118 [ESP600] /api/services/switch/toggle#{"entity_id": "switch.3d_printer_tuya_plug_5_switch"}
 */
 
 #define HOME_ASSISTANT_TOKEN "Bearer YOUR-TOKEN"

--- a/esp3d/notifications_service.cpp
+++ b/esp3d/notifications_service.cpp
@@ -354,14 +354,27 @@ bool NotificationsService::sendLineMSG(const char * title, const char * message)
 bool NotificationsService::sendPostRequestMSG(const char * title, const char * message)
 {
     HTTPClient http;
-    http.begin(_serveraddress.c_str(), _port, _settings);
+
+    // Split the message into path and JSON parts
+    // e.g message = "/api/services/light/toggle#{"entity_id": "light.wintergarten_spots"}"
+    String msgStr = String(message);
+    int hashIndex = msgStr.indexOf('#');
+    if (hashIndex == -1) return false;
+
+    String path = msgStr.substring(0, hashIndex);
+    String json = msgStr.substring(hashIndex + 1);
+    http.begin(_serveraddress.c_str(), _port, path);
+
     http.addHeader("Content-Type", "application/json");
     http.addHeader("Authorization", HOME_ASSISTANT_TOKEN);
-    int httpCode = http.POST(message);
-    bool result = (httpCode > 0) && (httpCode == HTTP_CODE_OK); // Example of basic success check
+
+    int httpCode = http.POST(json);
+    bool ok = (httpCode > 0) && (httpCode == HTTP_CODE_OK);
+
     http.end();
-    return result;
+    return ok;
 }
+
 //IFTTT
 bool NotificationsService::sendIFTTTMSG(const char * title, const char * message)
 {

--- a/esp3d/notifications_service.h
+++ b/esp3d/notifications_service.h
@@ -51,6 +51,7 @@ private:
     bool sendEmailMSG(const char * title, const char * message);
     bool sendLineMSG(const char * title, const char * message);
     bool sendIFTTTMSG(const char * title, const char * message);
+    bool sendPostRequestMSG(const char * title, const char * message);
     bool getPortFromSettings();
     bool getServerAddressFromSettings();
     bool getEmailFromSettings();


### PR DESCRIPTION
/* *** Home Assistant notification ***
 * Home Assistant tokens are too long to pass via serial.
 * Create a long-lived access token here: http://homeassistant.local:8123/profile
 * And replace "YOUR-TOKEN" below.
 * Usage: In a Marlin custom menu or at the end of your gcode add:
     M118 [ESP610]type=POST TS=#homeassistant.local:8123
     M118 [ESP600]/api/services/switch/toggle#{"entity_id": "switch.3d_printer_switch"}
*/

#define HOME_ASSISTANT_TOKEN "YOUR TOKEN"

Tested in an esp8266.
