### PR TITLE
Fixed ESP201 Command.

### DIFF
--- a/esp3d/src/core/commands/ESP201.cpp
+++ b/esp3d/src/core/commands/ESP201.cpp
@@ -123,8 +123,8 @@ void ESP3DCommands::ESP201(int cmd_params_pos, ESP3DMessage* msg) {
             }
           }
           value = digitalRead(pin);
-          ok_msg = String(value);
         }
+        ok_msg = String(value);
       }
     }
   }


### PR DESCRIPTION
Fixed the issue that ESP201 cannot display the ANALOG pin value.