### PR TITLE
Fix logical error in path validation for SD file handling

### DIFF
--- a/esp3d/src/modules/http/handlers/handle-SD-files.cpp
+++ b/esp3d/src/modules/http/handlers/handle-SD-files.cpp
@@ -100,7 +100,7 @@ void HTTP_Server::handleSDFileList() {
           status = shortname + " deleted";
           // what happen if no "/." and no other subfiles for SPIFFS like?
           String ptmp = path;
-          if ((path != "/") && (path[path.length() - 1] = '/')) {
+          if ((path != "/") && (path[path.length() - 1] == '/')) {
             ptmp = path.substring(0, path.length() - 1);
           }
           if (!ESP_SD::exists(ptmp.c_str())) {
@@ -160,7 +160,7 @@ void HTTP_Server::handleSDFileList() {
   buffer2send.reserve(1200);
   buffer2send = "{\"files\":[";
   String ptmp = path;
-  if ((path != "/") && (path[path.length() - 1] = '/')) {
+  if ((path != "/") && (path[path.length() - 1] == '/')) {
     ptmp = path.substring(0, path.length() - 1);
   }
   _webserver->setContentLength(CONTENT_LENGTH_UNKNOWN);

--- a/esp3d/src/modules/http/handlers/handle-files.cpp
+++ b/esp3d/src/modules/http/handlers/handle-files.cpp
@@ -88,7 +88,7 @@ void HTTP_Server::handleFSFileList() {
           status = shortname + " deleted";
           // what happen if no "/." and no other subfiles for SPIFFS like?
           String ptmp = path;
-          if ((path != "/") && (path[path.length() - 1] = '/')) {
+          if ((path != "/") && (path[path.length() - 1] == '/')) {
             ptmp = path.substring(0, path.length() - 1);
           }
           if (!ESP_FileSystem::exists(ptmp.c_str())) {
@@ -144,7 +144,7 @@ void HTTP_Server::handleFSFileList() {
   buffer2send.reserve(1200);
   buffer2send = "{\"files\":[";
   String ptmp = path;
-  if ((path != "/") && (path[path.length() - 1] = '/')) {
+  if ((path != "/") && (path[path.length() - 1] == '/')) {
     ptmp = path.substring(0, path.length() - 1);
   }
   _webserver->setContentLength(CONTENT_LENGTH_UNKNOWN);


### PR DESCRIPTION
This pull request fixes a bug in the `handleSDFileList` method in `handle-SD-files.cpp` by correcting the conditional check for a trailing slash in the `path` variable. The change replaces an assignment operator (`=`) with the correct equality operator (`==`), ensuring proper path handling. Without this fix, subfolders cannot be opened, and only the top-level directory of the SD card is visible.